### PR TITLE
standalone: Node selector and tolerations

### DIFF
--- a/neo4j-standalone/templates/neo4j-statefulset.yaml
+++ b/neo4j-standalone/templates/neo4j-statefulset.yaml
@@ -58,6 +58,14 @@ spec:
       {{- if $.Values.podSpec.serviceAccountName | or $clusterEnabled }}
       serviceAccountName: "{{ if kindIs "string" $.Values.podSpec.serviceAccountName | and $.Values.podSpec.serviceAccountName }}{{ $.Values.podSpec.serviceAccountName }}{{ else }}{{ .Release.Name }}{{ end }}"
       {{- end }}
+      {{- with .Values.podSpec.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSpec.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext: {{ toYaml .Values.securityContext | nindent 8 }}
       terminationGracePeriodSeconds: {{ if $offlineMaintenanceEnabled  }}0{{ else }}{{ .Values.podSpec.terminationGracePeriodSeconds }}{{ end }}
       {{- $initContainers := .Values.podSpec.initContainers }}

--- a/neo4j-standalone/values.yaml
+++ b/neo4j-standalone/values.yaml
@@ -315,6 +315,12 @@ podSpec:
   # additional runtime containers for the Neo4j pod
   containers: [ ]
 
+  # Node Selector(s) for scheduling the pods on specific Nodes
+  nodeSelector: {}
+
+  # Allow pods to be scheduled on nodes containing specific taints
+  tolerations: [ ]
+
 # print the neo4j user password set during install to the `helm install` log
 logInitialPassword: true
 


### PR DESCRIPTION
Added the option to add [`nodeSelector`](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) and/or [`tolerations`](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).

Possible values can be:
```
podSpec:
  
  nodeSelector:
    eks.amazonaws.com/capacityType: ON_DEMAND

  tolerations:
  - key: dedicated
    operator: Equal
    value: onDemandGroup
    effect: NoSchedule
```