### PR TITLE
Add possibility to specify a Node Affinity for the Pods in the Stateful Sets

### DIFF
--- a/neo4j-cluster-core/values.yaml
+++ b/neo4j-cluster-core/values.yaml
@@ -302,6 +302,11 @@ podSpec:
   # If set to an object then that object is used for the Neo4j podAntiAffinity
   podAntiAffinity: true
 
+  # Node Affinity
+  # If set to an object then that object is used for a nodeAffinity on the pods in the Stateful Set
+  # Optional
+  # nodeAffinity:
+
   #This indicates that the neo4j instance be included to the loadbalancer. Can be set to exclude to not add the stateful set to loadbalancer
   loadbalancer: "include"
 

--- a/neo4j-cluster-read-replica/values.yaml
+++ b/neo4j-cluster-read-replica/values.yaml
@@ -299,6 +299,11 @@ podSpec:
   # If set to an object then that object is used for the Neo4j podAntiAffinity
   podAntiAffinity: true
 
+  # Node Affinity
+  # If set to an object then that object is used for a nodeAffinity on the pods in the Stateful Set
+  # Optional
+  # nodeAffinity:
+
   #This indicates that the neo4j instance be included to the loadbalancer. Can be set to exclude to not add the stateful set to loadbalancer
   loadbalancer: "include"
 

--- a/neo4j-standalone/templates/neo4j-statefulset.yaml
+++ b/neo4j-standalone/templates/neo4j-statefulset.yaml
@@ -42,8 +42,9 @@ spec:
       annotations:
         "checksum/{{ .Release.Name }}-config": {{ include (print $.Template.BasePath "/neo4j-config.yaml") . | sha256sum }}
     spec:
-      {{- if .Values.podSpec.podAntiAffinity }}
+      {{- if (or .Values.podSpec.podAntiAffinity .Values.podSpec.nodeAffinity) }}
       affinity:
+        {{- if .Values.podSpec.podAntiAffinity }}
         {{- if kindIs "bool" .Values.podSpec.podAntiAffinity | and .Values.podSpec.podAntiAffinity }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -55,7 +56,11 @@ spec:
         {{- else }}
         podAntiAffinity: {{ toYaml .Values.podSpec.podAntiAffinity | nindent 10 }}
         {{- end }}
-      {{- end }}
+        {{- end }}
+        {{- if .Values.podSpec.nodeAffinity }}
+        nodeAffinity: {{ toYaml .Values.podSpec.nodeAffinity | nindent 10 }}
+        {{- end}}
+      {{- end}}
       {{- if $.Values.podSpec.serviceAccountName | or $clusterEnabled }}
       serviceAccountName: "{{ if kindIs "string" $.Values.podSpec.serviceAccountName | and $.Values.podSpec.serviceAccountName }}{{ $.Values.podSpec.serviceAccountName }}{{ else }}{{ .Release.Name }}{{ end }}"
       {{- end }}

--- a/neo4j-standalone/values.yaml
+++ b/neo4j-standalone/values.yaml
@@ -304,6 +304,11 @@ podSpec:
   # If set to an object then that object is used for the Neo4j podAntiAffinity
   podAntiAffinity: true
 
+  # Node Affinity
+  # If set to an object then that object is used for a nodeAffinity on the pods in the Stateful Set
+  # Optional
+  # nodeAffinity:
+
   #This indicates that the neo4j instance be included to the loadbalancer. Can be set to exclude to not add the stateful set to loadbalancer
   loadbalancer: "include"
 


### PR DESCRIPTION
Example use case: say you want to deploy a Causal Cluster to GKE using Compute Engine disks located in 3 different zones for better fault tolerance. In this case the pods in the Stateful Sets would need to be scheduled onto the same nodes as the persistent disk they refer to. One solution could be to assign a zone, a disk and a node to each Helm release of the neo4j-cluster-core chart and use values in `values.yaml` to bind together the pods in a Stateful Set in one release to the corresponding zone, disk and node, say by using the name of the zone (which is common for all 3 entities). The problem is that by default pods are not assigned to a node in the same zone as the persistent disk they refer to with a volume entry: they may be scheduled to a node in a different zone instead. To enforce the policy that the pods from a given release need to be scheduled onto a node in the right zone one could use a node affinity and the `topology.kubernetes.io/zone` label that is present on all nodes on a GKE cluster. In order to do this the chart would have to allow one to specify a node affinity. This PR is aimed to do that with a minimal code/structure change

**Edit**: Nevermind, I've just learned about the possibility to specify a node selector (very recent as well, from version 4.4.5): https://neo4j.com/docs/operations-manual/current/kubernetes/maintenance/#NodeSelector. This makes my change unnecessary for my example use case since a simple NodeSelector also would suffice. I will keep the PR open in case you'd like to still include the change (e.g. somebody else might actually have a use for a Node Affinity in place of a simple NodeSelector)