### PR TITLE
Add possibiliy to disable creation of Secret object for neo4j password

### DIFF
--- a/neo4j-cluster-core/values.yaml
+++ b/neo4j-cluster-core/values.yaml
@@ -13,7 +13,7 @@ neo4j:
   # for the neo4j user should be created
   # If set to true it will prevent the creation of the Secret object
   # If unset or set to false the default behaviour defined by the 'password' value will apply
-  # passwodSecretDisabled: true
+  # passwordSecretDisabled: true
 
   # Neo4j Clustering requires Enterprise Edition
   edition: "enterprise"

--- a/neo4j-cluster-core/values.yaml
+++ b/neo4j-cluster-core/values.yaml
@@ -9,6 +9,12 @@ neo4j:
   # If password is not set or empty a random password will be generated during installation
   password: ""
 
+  # A value specifying whether the creation of a Secret object holding the default password
+  # for the neo4j user should be created
+  # If set to true it will prevent the creation of the Secret object
+  # If unset or set to false the default behaviour defined by the 'password' value will apply
+  # passwodSecretDisabled: true
+
   # Neo4j Clustering requires Enterprise Edition
   edition: "enterprise"
 

--- a/neo4j-cluster-read-replica/values.yaml
+++ b/neo4j-cluster-read-replica/values.yaml
@@ -13,7 +13,7 @@ neo4j:
   # for the neo4j user should be created
   # If set to true it will prevent the creation of the Secret object
   # If unset or set to false the default behaviour defined by the 'password' value will apply
-  # passwodSecretDisabled: true
+  # passwordSecretDisabled: true
 
   # Neo4j Clustering requires Enterprise Edition
   edition: "enterprise"

--- a/neo4j-cluster-read-replica/values.yaml
+++ b/neo4j-cluster-read-replica/values.yaml
@@ -9,6 +9,12 @@ neo4j:
   # If password is not set or empty a random password will be generated during installation
   password: ""
 
+  # A value specifying whether the creation of a Secret object holding the default password
+  # for the neo4j user should be created
+  # If set to true it will prevent the creation of the Secret object
+  # If unset or set to false the default behaviour defined by the 'password' value will apply
+  # passwodSecretDisabled: true
+
   # Neo4j Clustering requires Enterprise Edition
   edition: "enterprise"
 

--- a/neo4j-standalone/templates/neo4j-auth.yaml
+++ b/neo4j-standalone/templates/neo4j-auth.yaml
@@ -23,7 +23,7 @@
   {{- $secretBelongsToSomeoneElse = index $secret.metadata.annotations "meta.helm.sh/release-name" | eq .Release.Name | not }}
 {{- end }}
 
-{{- $skipSecret := coalesce .Values.neo4j.passwodSecretDisabled false }}
+{{- $skipSecret := coalesce .Values.neo4j.passwordSecretDisabled false }}
 
 {{- if $secretBelongsToSomeoneElse -}}
 

--- a/neo4j-standalone/templates/neo4j-auth.yaml
+++ b/neo4j-standalone/templates/neo4j-auth.yaml
@@ -23,9 +23,13 @@
   {{- $secretBelongsToSomeoneElse = index $secret.metadata.annotations "meta.helm.sh/release-name" | eq .Release.Name | not }}
 {{- end }}
 
+{{- $skipSecret := coalesce .Values.neo4j.passwodSecretDisabled false }}
+
 {{- if $secretBelongsToSomeoneElse -}}
 
-  {{- if eq (len .Values.neo4j.password) 0 -}}
+  {{- if $skipSecret -}}
+      # Skipping creation of Secret resource for the neo4j password as explicitly requested
+  {{- else if eq (len .Values.neo4j.password) 0 -}}
 
     {{- $password := index $secret.data "NEO4J_AUTH" | b64dec | trimPrefix "neo4j/" -}}
     {{- $ignored := set .Values.neo4j "password" $password -}}

--- a/neo4j-standalone/templates/neo4j-auth.yaml
+++ b/neo4j-standalone/templates/neo4j-auth.yaml
@@ -25,7 +25,7 @@
 
 {{- $skipSecret := coalesce .Values.neo4j.passwordSecretDisabled false }}
 
-{{- if $secretBelongsToSomeoneElse -}}
+{{- if (or $secretBelongsToSomeoneElse $skipSecret) -}}
 
   {{- if $skipSecret -}}
       # Skipping creation of Secret resource for the neo4j password as explicitly requested

--- a/neo4j-standalone/values.yaml
+++ b/neo4j-standalone/values.yaml
@@ -12,7 +12,7 @@ neo4j:
   # for the neo4j user should be created
   # If set to true it will prevent the creation of the Secret object
   # If unset or set to false the default behaviour defined by the 'password' value will apply
-  # passwodSecretDisabled: true
+  # passwordSecretDisabled: true
 
   # Neo4j Edition to use (community|enterprise)
   edition: "community"

--- a/neo4j-standalone/values.yaml
+++ b/neo4j-standalone/values.yaml
@@ -8,6 +8,12 @@ neo4j:
   # If password is not set or empty a random password will be generated during installation
   password: ""
 
+  # A value specifying whether the creation of a Secret object holding the default password
+  # for the neo4j user should be created
+  # If set to true it will prevent the creation of the Secret object
+  # If unset or set to false the default behaviour defined by the 'password' value will apply
+  # passwodSecretDisabled: true
+
   # Neo4j Edition to use (community|enterprise)
   edition: "community"
   # set edition: "enterprise" to use Neo4j Enterprise Edition


### PR DESCRIPTION
Example use case: say your installations of multiple Helm releases (e.g. to create a causal cluster) are started and done in parallel (e.g. this is the case if one uses Terraform with the `helm_release` resource and a `count` parameter). In this case the automatic detection of the Secret object used to hold the default password for the neo4j account by the other releases might not happen due what basically is a data race: at the moment at which all releases installations are started no secret object exists, so a secret object is added to the manifest of all of them. However, this will result in a conflict later on when one release successfully creates the secret resource and the others will fail right afterwards. A solution might be to serialise the installation of the helm releases, but that might not always be a viable or convenient solution. This PR tries to address this problem with a minimal change by adding the possibility to specify a value that prevents a release from creating the aforementioned Secret resource. This can be used to designate one release that is supposed to create the secret while disabling the creation of the secret for all other resources. Not specifying the value just falls back to the previous default behaviour, defined by the value of the `password` value.