### PR TITLE
Fix duplicate `dbms.connector.https.enabled` key in default-config ConfigMap on neo4j-standalone

### DIFF
--- a/neo4j-standalone/neo4j-community.conf
+++ b/neo4j-standalone/neo4j-community.conf
@@ -97,7 +97,7 @@ dbms.connector.http.enabled=true
 #dbms.connector.http.advertised_address=:7474
 
 # HTTPS Connector. There can be zero or one HTTPS connectors.
-dbms.connector.https.enabled=false
+#dbms.connector.https.enabled=false
 #dbms.connector.https.listen_address=:7473
 #dbms.connector.https.advertised_address=:7473
 

--- a/neo4j-standalone/neo4j-enterprise.conf
+++ b/neo4j-standalone/neo4j-enterprise.conf
@@ -113,7 +113,7 @@ dbms.connector.http.enabled=true
 #dbms.connector.http.advertised_address=:7474
 
 # HTTPS Connector. There can be zero or one HTTPS connectors.
-dbms.connector.https.enabled=false
+#dbms.connector.https.enabled=false
 #dbms.connector.https.listen_address=:7473
 #dbms.connector.https.advertised_address=:7473
 

--- a/neo4j-standalone/templates/neo4j-config.yaml
+++ b/neo4j-standalone/templates/neo4j-config.yaml
@@ -143,8 +143,10 @@ data:
 
   {{- if .Values.ssl.https.privateKey.secretName }}
   dbms.connector.https.enabled: "true"
+  {{- else }}
+  dbms.connector.https.enabled: "false"
   {{- end }}
-
+  
   {{- range $name, $sslSpec := .Values.ssl }}
   {{- if $sslSpec.privateKey.secretName }}
   # Automatically enable SSL policy for {{ $name }} because privateKey secret is present


### PR DESCRIPTION
This PR fixes a bug in the `neo4j-standalone` template which causes a duplicate `dbms.connector.https.enabled` key to be created in the [`{{ .Release.Name }}-default-config`](https://github.com/neo4j/helm-charts/blob/dev/neo4j-standalone/templates/neo4j-config.yaml#L63-L154) ConfigMap.

`dbms.connector.https.enabled` [is set in `neo4j-community.conf`](https://github.com/neo4j/helm-charts/blob/dev/neo4j-standalone/neo4j-community.conf#L100) and [`neo4j-enterpise.conf`](https://github.com/neo4j/helm-charts/blob/dev/neo4j-standalone/neo4j-enterprise.conf#L116) and [imported as a ConfigMap key into the `{{ .Release.Name }}-default-config` ConfigMap](https://github.com/neo4j/helm-charts/blob/dev/neo4j-standalone/templates/neo4j-config.yaml#L76). However, a duplicate `dbms.connector.https.enabled` key [is created](https://github.com/neo4j/helm-charts/blob/dev/neo4j-standalone/templates/neo4j-config.yaml#L144-L146) if the user has set `ssl.https.privateKey.secretName` in values.yaml.

Note the two `dbms.connector.https.enabled` keys in the resulting ConfigMap:
```yaml
# Source: neo4j-standalone/templates/neo4j-config.yaml
# Default Neo4j config values, these are overridden by user-provided values in neo4j-standalone-user-config
apiVersion: v1
kind: ConfigMap
metadata:
  name: "neo4j-standalone-default-config"
  namespace: "foo"
  labels:
    app: "bar"    
data:

  # Neo4j defaults
  dbms.tx_state.memory_allocation: ON_HEAP
  dbms.connector.bolt.enabled: 'true'
  dbms.connector.http.enabled: 'true'
  dbms.connector.https.enabled: 'false'
  dbms.tx_log.rotation.retention_policy: 1 days
  dbms.windows_service_name: neo4j

  # Helm defaults
  dbms.mode: "SINGLE"

  # Bolt keep alive
  # this helps to ensure that LoadBalancers do not close bolt connections that are in use but appear idle
  dbms.connector.bolt.connection_keep_alive: "30s"
  dbms.connector.bolt.connection_keep_alive_for_requests: "ALL"
  dbms.connector.bolt.connection_keep_alive_streaming_scheduling_interval: "30s"

  # If we set default advertised address it over-rides the bolt address used to populate the browser in a really annoying way
  # dbms.default_advertised_address: "$(bash -c 'echo ${SERVICE_DOMAIN}')"


  # Other
  dbms.config.strict_validation: "true"
  dbms.logs.user.stdout_enabled: "false"
  unsupported.dbms.ssl.system.ignore_dot_files: "true"
  # Logging
  dbms.directories.logs: "/logs"
  # Import
  dbms.directories.import: "/import"

  # Use more reliable defaults SSL / TLS settings for K8s
  dbms.ssl.policy.bolt.client_auth: "NONE"
  dbms.ssl.policy.https.client_auth: "NONE"
  dbms.connector.bolt.tls_level: "REQUIRED"
  dbms.connector.https.enabled: "true"
  # Automatically enable SSL policy for bolt because privateKey secret is present
  dbms.ssl.policy.bolt.enabled: "true"
  # Automatically enable SSL policy for https because privateKey secret is present
  dbms.ssl.policy.https.enabled: "true"

```

Duplicate keys [violate the YAML 1.2 specification](https://yaml.org/spec/1.2.2/#3213-node-comparison), which means documents with duplicate keys [will fail validation by the likes of `go-yaml`](https://github.com/go-yaml/yaml/issues/154#issuecomment-376271248), which is the underlying yaml parsing library used by popular Kubernetes tools like [kustomize](https://github.com/kubernetes-sigs/kustomize), resulting in errors like:
```
Error: map[string]interface {}(nil): yaml: unmarshal errors:
  line 41: mapping key "dbms.connector.https.enabled" already defined at line 16
```

Related kustomize PR: https://github.com/kubernetes-sigs/kustomize/pull/4096

Same issue on GitLab's helm chart: https://gitlab.com/gitlab-org/charts/gitlab/-/issues/2582