### PR TITLE
Support advanced configuration for env in neo4j-standalone

### DIFF
--- a/neo4j/templates/neo4j-statefulset.yaml
+++ b/neo4j/templates/neo4j-statefulset.yaml
@@ -105,6 +105,9 @@ spec:
               value: "{{ include "neo4j.fullname" . }}-internals.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
             - name: SERVICE_NEO4J
               value: "{{ include "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+            {{- if .Values.advancedEnv }}
+            {{- .Values.advancedEnv | toYaml | nindent 12 }}
+            {{- end }}
           ports:
             - containerPort: 7474
               name: http

--- a/neo4j/values.yaml
+++ b/neo4j/values.yaml
@@ -353,6 +353,14 @@ statefulset:
 # additional environment variables for the Neo4j Container
 env: {}
 
+# advanced environment variables for the Neo4j Container
+#advancedEnv:
+#  - name: apoc.jdbc.mydb.url
+#    valueFrom:
+#      secretKeyRef:
+#        name: mydb-secret
+#        key: jdbc-url
+
 # Other K8s configuration to apply to the Neo4j pod
 podSpec:
 


### PR DESCRIPTION
User can configure the env with "configMapKeyRef" and "secretKeyRef" with the value "advancedEnv".

Fixes #98

Signed-off-by: John Lin <johnlinp@gmail.com>