### PR TITLE
Fix bug with uninstall hook on EKS clusters

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,7 +1,7 @@
 # This dockerfile provides all the dependencies necessart to run go test on this project
 FROM gcr.io/google.com/cloudsdktool/cloud-sdk:slim
 
-ENV HELM_VERSION="v3.9.4" VERIFY_CHECKSUM="true" VERIFY_SIGNATURES="true" GO_VERSION="1.19" SHELL=bash
+ENV HELM_VERSION="v3.9.4" VERIFY_CHECKSUM="true" VERIFY_SIGNATURES="false" GO_VERSION="1.19" SHELL=bash
 COPY docker_resources/* /tmp/
 
 # use bash as the default shell (https://unix.stackexchange.com/questions/442510/how-to-use-bash-for-sh-in-ubuntu)

--- a/build/docker_resources/get-helm-3
+++ b/build/docker_resources/get-helm-3
@@ -51,7 +51,7 @@ initOS() {
 
   case "$OS" in
     # Minimalist GNU for Windows
-    mingw*) OS='windows';;
+    mingw*|cygwin*) OS='windows';;
   esac
 }
 
@@ -105,9 +105,9 @@ checkDesiredVersion() {
     # Get tag from release URL
     local latest_release_url="https://github.com/helm/helm/releases"
     if [ "${HAS_CURL}" == "true" ]; then
-      TAG=$(curl -Ls $latest_release_url | grep 'href="/helm/helm/releases/tag/v3.[0-9]*.[0-9]*\"' | grep -v no-underline | head -n 1 | cut -d '"' -f 2 | awk '{n=split($NF,a,"/");print a[n]}' | awk 'a !~ $0{print}; {a=$0}')
+      TAG=$(curl -Ls $latest_release_url | grep 'href="/helm/helm/releases/tag/v3.[0-9]*.[0-9]*\"' | sed -E 's/.*\/helm\/helm\/releases\/tag\/(v[0-9\.]+)".*/\1/g' | head -1)
     elif [ "${HAS_WGET}" == "true" ]; then
-      TAG=$(wget $latest_release_url -O - 2>&1 | grep 'href="/helm/helm/releases/tag/v3.[0-9]*.[0-9]*\"' | grep -v no-underline | head -n 1 | cut -d '"' -f 2 | awk '{n=split($NF,a,"/");print a[n]}' | awk 'a !~ $0{print}; {a=$0}')
+      TAG=$(wget $latest_release_url -O - 2>&1 | grep 'href="/helm/helm/releases/tag/v3.[0-9]*.[0-9]*\"' | sed -E 's/.*\/helm\/helm\/releases\/tag\/(v[0-9\.]+)".*/\1/g' | head -1)
     fi
   else
     TAG=$DESIRED_VERSION

--- a/index.yaml
+++ b/index.yaml
@@ -1,6 +1,39 @@
 apiVersion: v1
 generated: 2022-01-28T12:15:12.380915000+00:00
 entries:
+  neo4j:
+    - created: 2022-11-09T15:53:01.189063000+00:00
+      description: Neo4j 5.1.0
+      digest: 21c989a31aa158a5ee583165c2a67b7148fa980d59e17743fefbd84aa00da5b8
+      home: https://github.com/neo4j/helm-charts
+      name: neo4j
+      sources:
+        - https://github.com/neo4j/helm-charts/tree/5.1/neo4j
+      urls:
+        - https://github.com/neo4j/helm-charts/releases/download/5.1.0/neo4j-5.1.0.tgz
+      version: 5.1.0
+  neo4j-persistent-volume:
+    - created: 2022-11-09T15:53:01.189063000+00:00
+      description: Neo4j Headless Service 5.1.0
+      digest: 3d6dc2b9b3712a2b6f301113aab8034e681836e4d9309d913dad46bdbe9b3df0
+      home: https://github.com/neo4j/helm-charts
+      name: neo4j-persistent-volume
+      sources:
+        - https://github.com/neo4j/helm-charts/tree/5.1/neo4j-persistent-volume
+      urls:
+        - https://github.com/neo4j/helm-charts/releases/download/5.1.0/neo4j-persistent-volume-5.1.0.tgz
+      version: 5.1.0
+  neo4j-headless-service:
+    - created: 2022-11-09T15:53:01.189063000+00:00
+      description: Neo4j Headless Service 5.1.0
+      digest: 7e185963295d2c6ada90a55c6418d9b2965893c7047cfad113a0e3e91e958cb0
+      home: https://github.com/neo4j/helm-charts
+      name: neo4j-headless-service
+      sources:
+        - https://github.com/neo4j/helm-charts/tree/5.1/neo4j-headless-service
+      urls:
+        - https://github.com/neo4j/helm-charts/releases/download/5.1.0/neo4j-headless-service-5.1.0.tgz
+      version: 5.1.0
   neo4j-standalone:
     - created: 2022-08-10T15:50:18.517974000+01:00
       description: Neo4j Standalone 4.4.10

--- a/neo4j-headless-service/Chart.yaml
+++ b/neo4j-headless-service/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: neo4j-headless-service
 home: https://www.neo4j.com
-version: 5.1.0
+version: 5.1.1
 appVersion: "-"
 description: Neo4j is the world's leading graph database
 keywords:

--- a/neo4j-persistent-volume/Chart.yaml
+++ b/neo4j-persistent-volume/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: neo4j-persistent-volume
 home: https://www.neo4j.com
-version: 5.1.0
+version: 5.1.1
 appVersion: "-"
 description: Sets up persistent disks suitable for a Neo4j Helm installation
 keywords:

--- a/neo4j/Chart.yaml
+++ b/neo4j/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: neo4j
 home: https://www.neo4j.com
-version: 5.1.0
+version: 5.1.1
 appVersion: 5.1.0
 description: Neo4j is the world's leading graph database
 keywords:

--- a/neo4j/templates/_image.tpl
+++ b/neo4j/templates/_image.tpl
@@ -31,7 +31,7 @@
     {{- $registryName := .registry -}}
     {{- $repositoryName := .repository -}}
     {{- $separator := ":" -}}
-    {{- $termination := printf "%s.%s" $.Capabilities.KubeVersion.Major $.Capabilities.KubeVersion.Minor -}}
+    {{- $termination := printf "%s.%s" $.Capabilities.KubeVersion.Major (regexReplaceAll "\\D+" $.Capabilities.KubeVersion.Minor "") -}}
     {{- if not (empty (.tag | trim)) -}}
         {{- $termination := .tag | toString -}}
     {{- end -}}


### PR DESCRIPTION
Uninstall fails on EKS clusters becuase the kubernetes minor version contains a "+" character. The version is used to decide which kubectl image to use
Use regex replace to remove any non-numeric chars in the minor version

Bump chart versions to 5.1.1
