### PR TITLE
Implement nameOverrides and fullnameOverrides

### DIFF
--- a/internal/model/release_values.go
+++ b/internal/model/release_values.go
@@ -3,6 +3,8 @@ package model
 import v1 "k8s.io/api/core/v1"
 
 type HelmValues struct {
+	FullnameOverride       string            `yaml:"fullnameOverride,omitempty"`
+	NameOverride           string            `yaml:"nameOverride,omitempty"`
 	Neo4J                  Neo4J             `yaml:"neo4j,omitempty"`
 	Volumes                Volumes           `yaml:"volumes,omitempty"`
 	AdditionalVolumes      []interface{}     `yaml:"additionalVolumes,omitempty"`

--- a/neo4j/templates/_helpers.tpl
+++ b/neo4j/templates/_helpers.tpl
@@ -1,5 +1,40 @@
 {{/* vim: set filetype=mustache: */}}
 {{/*
+Expand the name of the chart.
+*/}}
+{{- define "neo4j.defaultName" -}}
+    {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "neo4j.chart" -}}
+    {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "neo4j.fullname" -}}
+    {{- if .Values.fullnameOverride -}}
+        {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+    {{- else -}}
+        {{- if .Values.nameOverride -}}
+            {{- $name := default .Chart.Name .Values.nameOverride -}}
+            {{- if contains $name .Release.Name -}}
+                {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+            {{- else -}}
+                {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+            {{- end -}}
+       {{- else -}}
+            {{- printf "%s" .Release.Name | trunc 63 | trimSuffix "-" -}}
+       {{- end -}}
+    {{- end -}}
+{{- end -}}
+
+{{/*
 Convert a neo4j.conf properties text into valid yaml
 */}}
 {{- define "neo4j.configYaml" -}}

--- a/neo4j/templates/_helpers.tpl
+++ b/neo4j/templates/_helpers.tpl
@@ -1,17 +1,4 @@
 {{/* vim: set filetype=mustache: */}}
-{{/*
-Expand the name of the chart.
-*/}}
-{{- define "neo4j.defaultName" -}}
-    {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{/*
-Create chart name and version as used by the chart label.
-*/}}
-{{- define "neo4j.chart" -}}
-    {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
 
 {{/*
 Create a default fully qualified app name.
@@ -96,17 +83,6 @@ Convert a neo4j.conf properties text into valid yaml
 {{- end -}}
 
 {{/*
-If no name is set in `Values.neo4j.name` sets it to release name and modifies Values.neo4j so that the same name is available everywhere
-*/}}
-{{/*{{- define "neo4j.name" -}}*/}}
-{{/*  {{- if not .Values.neo4j.name }}*/}}
-{{/*    {{- $name := .Release.Name }}*/}}
-{{/*    {{- $ignored := set .Values.neo4j "name" $name }}*/}}
-{{/*  {{- end -}}*/}}
-{{/*  {{- .Values.neo4j.name }}*/}}
-{{/*{{- end -}}*/}}
-
-{{/*
 If no password is set in `Values.neo4j.password` generates a new random password and modifies Values.neo4j so that the same password is available everywhere
 */}}
 {{- define "neo4j.password" -}}
@@ -122,39 +98,6 @@ If no password is set in `Values.neo4j.password` generates a new random password
   {{- end -}}
   {{- .Values.neo4j.password }}
 {{- end -}}
-
-{{/*{{- define "neo4j.checkIfClusterIsPresent" -}}*/}}
-
-{{/*    {{- $name := .Values.neo4j.name -}}*/}}
-{{/*    {{- $clusterList := list -}}*/}}
-{{/*    {{- range $index,$pod := (lookup "v1" "Pod" .Release.Namespace "").items -}}*/}}
-{{/*        {{- if eq $name (index $pod.metadata.labels "helm.neo4j.com/neo4j.name" | toString) -}}*/}}
-{{/*            {{- if eq (index $pod.metadata.labels "helm.neo4j.com/dbms.mode" | toString) "CORE" -}}*/}}
-
-{{/*                {{- $noOfContainers := len (index $pod.status.containerStatuses) -}}*/}}
-{{/*                {{- $noOfReadyContainers := 0 -}}*/}}
-
-{{/*                {{- range $index,$value := index $pod.status.containerStatuses -}}*/}}
-{{/*                    {{- if $value.ready }}*/}}
-{{/*                        {{- $noOfReadyContainers = add1 $noOfReadyContainers -}}*/}}
-{{/*                    {{- end -}}*/}}
-{{/*                {{- end -}}*/}}
-
-{{/*                */}}{{/* Number of Ready Containers should be equal to the number of containers in the pod */}}
-{{/*                */}}{{/* Pod should be in running state */}}
-{{/*                {{- if and (eq $noOfReadyContainers $noOfContainers) (eq (index $pod.status.phase | toString) "Running") -}}*/}}
-{{/*                    {{- $clusterList = append $clusterList (index $pod.metadata.name) -}}*/}}
-{{/*                {{- end -}}*/}}
-
-{{/*            {{- end -}}*/}}
-{{/*        {{- end -}}*/}}
-{{/*    {{- end -}}*/}}
-
-{{/*    {{- if lt (len $clusterList) 3 -}}*/}}
-{{/*        {{ fail "Cannot install Read Replica until a cluster of 3 or more cores is formed" }}*/}}
-{{/*    {{- end -}}*/}}
-
-{{/*{{- end -}}*/}}
 
 {{- define "podSpec.checkLoadBalancerParam" }}
 {{- $isLoadBalancerValuePresent := required (include "podSpec.loadBalancer.mustBeSetMessage" .) .Values.podSpec.loadbalancer | regexMatch "(?i)include$|(?i)exclude$" -}}

--- a/neo4j/templates/delete-loadbalancer-hook.yaml
+++ b/neo4j/templates/delete-loadbalancer-hook.yaml
@@ -4,9 +4,9 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ .Release.Name }}-cleanup"
+  name: "{{ include "neo4j.fullname" . }}-cleanup"
   labels:
-    app: "{{ .Release.Name }}-cleanup"
+    app: "{{ include "neo4j.fullname" . }}-cleanup"
     {{- include "neo4j.labels" $.Values.neo4j | indent 4 }}
   annotations:
     "helm.sh/hook": "pre-delete"
@@ -15,9 +15,9 @@ spec:
   template:
     metadata:
       labels:
-        app: "{{ .Release.Name }}-cleanup"
+        app: "{{ include "neo4j.fullname" . }}-cleanup"
     spec:
-      serviceAccountName: "{{ .Release.Name }}-cleanup"
+      serviceAccountName: "{{ include "neo4j.fullname" . }}-cleanup"
       containers:
         - name: kubectl
           image: "{{ include "cleanup.image" . }}"
@@ -33,7 +33,7 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: "{{ .Release.Name }}-cleanup"
+  name: "{{ include "neo4j.fullname" . }}-cleanup"
   labels:
     app: "{{ template "neo4j.name" $ }}"
     {{- include "neo4j.labels" $.Values.neo4j | indent 4 }}
@@ -41,7 +41,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: "{{ .Release.Name }}-cleanup"
+  name: "{{ include "neo4j.fullname" . }}-cleanup"
   labels:
     app: "{{ template "neo4j.name" $ }}"
     {{- include "neo4j.labels" $.Values.neo4j | indent 4 }}
@@ -53,15 +53,15 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: "{{ .Release.Name }}-cleanup"
+  name: "{{ include "neo4j.fullname" . }}-cleanup"
   labels:
     app: "{{ template "neo4j.name" $ }}"
     {{- include "neo4j.labels" $.Values.neo4j | indent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: "{{ .Release.Name }}-cleanup"
+    name: "{{ include "neo4j.fullname" . }}-cleanup"
 roleRef:
   kind: Role # this must be Role or ClusterRole
-  name: "{{ .Release.Name }}-cleanup" # this must match the name of the Role or ClusterRole you wish to bind to
+  name: "{{ include "neo4j.fullname" . }}-cleanup" # this must match the name of the Role or ClusterRole you wish to bind to
   apiGroup: rbac.authorization.k8s.io
 {{- end -}}

--- a/neo4j/templates/neo4j-config.yaml
+++ b/neo4j/templates/neo4j-config.yaml
@@ -5,7 +5,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "{{ .Release.Name }}-k8s-config"
+  name: "{{ include "neo4j.fullname" . }}-k8s-config"
   namespace: "{{ .Release.Namespace }}"
   labels:
     app: "{{ template "neo4j.name" $ }}"
@@ -23,7 +23,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "{{ .Release.Name }}-user-config"
+  name: "{{ include "neo4j.fullname" . }}-user-config"
   namespace: "{{ .Release.Namespace }}"
   labels:
     app: "{{ template "neo4j.name" $ }}"
@@ -60,11 +60,11 @@ data:
   {{- end }}
   {{- end }}
 ---
-# Default Neo4j config values, these are overridden by user-provided values in {{ .Release.Name }}-user-config
+# Default Neo4j config values, these are overridden by user-provided values in {{ include "neo4j.fullname" . }}-user-config
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "{{ .Release.Name }}-default-config"
+  name: "{{ include "neo4j.fullname" . }}-default-config"
   namespace: "{{ .Release.Namespace }}"
   labels:
     app: "{{ template "neo4j.name" $ }}"
@@ -157,7 +157,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "{{ .Release.Name }}-apoc-config"
+  name: "{{ include "neo4j.fullname" . }}-apoc-config"
   namespace: "{{ .Release.Namespace }}"
   labels:
     app: "{{ template "neo4j.name" $ }}"
@@ -181,7 +181,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "{{ .Release.Name }}-server-logs-config"
+  name: "{{ include "neo4j.fullname" . }}-server-logs-config"
   namespace: "{{ .Release.Namespace }}"
   labels:
     app: "{{ template "neo4j.name" $ }}"
@@ -198,7 +198,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "{{ .Release.Name }}-user-logs-config"
+  name: "{{ include "neo4j.fullname" . }}-user-logs-config"
   namespace: "{{ .Release.Namespace }}"
   labels:
     app: "{{ template "neo4j.name" $ }}"

--- a/neo4j/templates/neo4j-env.yaml
+++ b/neo4j/templates/neo4j-env.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "{{ .Release.Name }}-env"
+  name: "{{ include "neo4j.fullname" . }}-env"
   namespace: "{{ .Release.Namespace }}"
   labels:
     app: "{{ template "neo4j.name" $ }}"
     {{- include "neo4j.labels" $.Values.neo4j | indent 4 }}
 data:
   # It should not be necessary for neo4j users/administrators to modify this configMap
-  # Neo4j configuration is set in the {{ .Release.Name }}-user-config ConfigMap
+  # Neo4j configuration is set in the {{ include "neo4j.fullname" . }}-user-config ConfigMap
   {{- if eq .Values.neo4j.acceptLicenseAgreement "yes" }}
   NEO4J_ACCEPT_LICENSE_AGREEMENT: "yes"
   {{- end }}

--- a/neo4j/templates/neo4j-imagePullSecret.yaml
+++ b/neo4j/templates/neo4j-imagePullSecret.yaml
@@ -23,7 +23,7 @@ metadata:
    name: "{{ $imageCredentialElement.name }}"
    namespace: "{{ $.Release.Namespace }}"
    labels:
-     app: "{{ $.Values.neo4j.name | default $.Release.Name }}"
+     app: "{{ $.Values.neo4j.name }}"
     {{- include "neo4j.labels" $.Values.neo4j | indent 4 }}
 type: kubernetes.io/dockerconfigjson
 data:

--- a/neo4j/templates/neo4j-service-account.yaml
+++ b/neo4j/templates/neo4j-service-account.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   namespace: "{{ .Release.Namespace }}"
-  name: {{ .Release.Name }}
+  name: {{ include "neo4j.fullname" . }}
   labels:
     app: "{{ template "neo4j.name" $ }}"
     {{- include "neo4j.labels" $.Values.neo4j | indent 4 }}
@@ -14,7 +14,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   namespace: "{{ .Release.Namespace }}"
-  name: "{{ .Release.Name }}-service-reader"
+  name: "{{ include "neo4j.fullname" . }}-service-reader"
   labels:
     app: "{{ template "neo4j.name" $ }}"
     {{- include "neo4j.labels" $.Values.neo4j | indent 4 }}
@@ -27,16 +27,16 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   namespace: "{{ .Release.Namespace }}"
-  name: "{{ .Release.Name }}-service-binding"
+  name: "{{ include "neo4j.fullname" . }}-service-binding"
   labels:
     app: "{{ template "neo4j.name" $ }}"
     {{- include "neo4j.labels" $.Values.neo4j | indent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: {{ .Release.Name }}
+    name: {{ include "neo4j.fullname" . }}
 roleRef:
   # "roleRef" specifies the binding to a Role / ClusterRole
   kind: Role # this must be Role or ClusterRole
-  name: {{ .Release.Name }}-service-reader # this must match the name of the Role or ClusterRole you wish to bind to
+  name: {{ include "neo4j.fullname" . }}-service-reader # this must match the name of the Role or ClusterRole you wish to bind to
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/neo4j/templates/neo4j-statefulset.yaml
+++ b/neo4j/templates/neo4j-statefulset.yaml
@@ -16,22 +16,22 @@ metadata:
     helm.neo4j.com/neo4j.name: "{{ template "neo4j.name" $ }}"
     helm.neo4j.com/clustering: "{{ $clusterEnabled }}"
     app: "{{ template "neo4j.name" . }}"
-    helm.neo4j.com/instance: "{{ .Release.Name }}"
+    helm.neo4j.com/instance: {{ include "neo4j.fullname" . }}
     {{- include "neo4j.labels" $.Values.neo4j | indent 4 }}
-  name: "{{ .Release.Name }}"
+  name: {{ include "neo4j.fullname" . }}
   namespace: "{{ .Release.Namespace }}"
   {{- if not (empty $.Values.statefulset.metadata.annotations) }}
   annotations:
     {{- include "neo4j.annotations" $.Values.statefulset.metadata.annotations | indent 4 }}
   {{- end }}
 spec:
-  serviceName: "{{ .Release.Name }}"
+  serviceName: "{{ include "neo4j.fullname" . }}"
   podManagementPolicy: "Parallel" # This setting means that the StatefulSet controller doesn't block applying changes until the existing Pod is READY.
   replicas: 1
   selector:
     matchLabels:
       app: "{{ template "neo4j.name" . }}"
-      helm.neo4j.com/instance: "{{ .Release.Name }}"
+      helm.neo4j.com/instance: "{{ include "neo4j.fullname" . }}"
   template:
     metadata:
       labels:
@@ -40,15 +40,15 @@ spec:
         helm.neo4j.com/clustering: "{{ $clusterEnabled }}"
         helm.neo4j.com/pod_category: "neo4j-instance" # used for anti affinity rules
         helm.neo4j.com/neo4j.loadbalancer: "{{ $.Values.podSpec.loadbalancer }}"
-        helm.neo4j.com/instance: "{{ .Release.Name }}"
+        helm.neo4j.com/instance: "{{ include "neo4j.fullname" . }}"
         {{- include "neo4j.labels" $.Values.neo4j | indent 8 }}
       annotations:
-        "checksum/{{ .Release.Name }}-config": {{ include (print $.Template.BasePath "/neo4j-config.yaml") . | sha256sum }}
+        "checksum/{{ include "neo4j.fullname" . }}-config": {{ include (print $.Template.BasePath "/neo4j-config.yaml") . | sha256sum }}
         {{- include "neo4j.annotations" $.Values.podSpec.annotations | indent 8 }}
     spec:
       {{- include "neo4j.affinity" . | indent 6 }}
       {{- if $.Values.podSpec.serviceAccountName | or $clusterEnabled }}
-      serviceAccountName: "{{ if kindIs "string" $.Values.podSpec.serviceAccountName | and $.Values.podSpec.serviceAccountName }}{{ $.Values.podSpec.serviceAccountName }}{{ else }}{{ .Release.Name }}{{ end }}"
+      serviceAccountName: "{{ if kindIs "string" $.Values.podSpec.serviceAccountName | and $.Values.podSpec.serviceAccountName }}{{ $.Values.podSpec.serviceAccountName }}{{ else }}{{ include "neo4j.fullname" . }}{{ end }}"
       {{- end }}
       securityContext: {{ toYaml .Values.securityContext | nindent 8 }}
       {{- include "neo4j.tolerations" .Values.podSpec.tolerations | nindent 6 }}
@@ -85,7 +85,7 @@ spec:
           {{- end }}
           envFrom:
             - configMapRef:
-                name: "{{ .Release.Name }}-env"
+                name: "{{ include "neo4j.fullname" . }}-env"
             {{- if not $authDisabled }}
             - secretRef:
                 name: "{{ template "neo4j.name" . }}-auth"
@@ -100,11 +100,11 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: SERVICE_NEO4J_ADMIN
-              value: "{{ .Release.Name }}-admin.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+              value: "{{ include "neo4j.fullname" . }}-admin.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
             - name: SERVICE_NEO4J_INTERNALS
-              value: "{{ .Release.Name }}-internals.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+              value: "{{ include "neo4j.fullname" . }}-internals.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
             - name: SERVICE_NEO4J
-              value: "{{ .Release.Name }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+              value: "{{ include "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
           ports:
             - containerPort: 7474
               name: http
@@ -180,17 +180,17 @@ spec:
             defaultMode: 0440
             sources:
               - configMap:
-                  name: "{{ .Release.Name }}-default-config"
+                  name: "{{ include "neo4j.fullname" . }}-default-config"
               - configMap:
-                  name: "{{ .Release.Name }}-user-config"
+                  name: "{{ include "neo4j.fullname" . }}-user-config"
               - configMap:
-                  name: "{{ .Release.Name }}-k8s-config"
+                  name: "{{ include "neo4j.fullname" . }}-k8s-config"
         - name: neo4j-server-logs
           configMap:
-            name: "{{ .Release.Name }}-server-logs-config"
+            name: "{{ include "neo4j.fullname" . }}-server-logs-config"
         - name: neo4j-user-logs
           configMap:
-            name: "{{ .Release.Name }}-user-logs-config"
+            name: "{{ include "neo4j.fullname" . }}-user-logs-config"
         {{- include "neo4j.additionalVolumes" .Values.additionalVolumes | nindent 8 }}
         {{- include "neo4j.apoc.volume" . | nindent 8 }}
         {{- with include "neo4j.ssl.volumesFromSecrets" .Values.ssl }}{{ nindent 8 .}}{{ end -}}

--- a/neo4j/templates/neo4j-svc.yaml
+++ b/neo4j/templates/neo4j-svc.yaml
@@ -14,12 +14,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ $.Release.Name }}"
+  name: "{{ include "neo4j.fullname" . }}"
   namespace: "{{ $.Release.Namespace }}"
   labels:
     helm.neo4j.com/neo4j.name: "{{ template "neo4j.name" $ }}"
     app: "{{ template "neo4j.name" $ }}"
-    helm.neo4j.com/instance: "{{ $.Release.Name }}"
+    helm.neo4j.com/instance: "{{ include "neo4j.fullname" . }}"
     helm.neo4j.com/service: "default"
     {{- include "neo4j.labels" $.Values.neo4j | indent 4 }}
   {{- with .Values.services.default.annotations }}
@@ -31,7 +31,7 @@ spec:
   {{- with .spec }}{{- include "neo4j.services.extraSpec" . | nindent 2 }}{{- end }}
   selector:
     app: "{{ template "neo4j.name" $ }}"
-    helm.neo4j.com/instance: "{{ $.Release.Name }}"
+    helm.neo4j.com/instance: "{{ include "neo4j.fullname" . }}"
   ports:
     - protocol: TCP
       port: 7687
@@ -52,12 +52,12 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ $.Release.Name }}-admin"
+  name: "{{ include "neo4j.fullname" $ }}-admin"
   namespace: "{{ $.Release.Namespace }}"
   labels:
     helm.neo4j.com/neo4j.name: "{{ template "neo4j.name" $ }}"
     app: "{{ template "neo4j.name" $ }}"
-    helm.neo4j.com/instance: "{{ $.Release.Name }}"
+    helm.neo4j.com/instance: "{{ include "neo4j.fullname" $ }}"
     helm.neo4j.com/service: "admin"
     {{- include "neo4j.labels" $.Values.neo4j | indent 4 }}
   {{- with .annotations }}
@@ -69,7 +69,7 @@ spec:
   {{- with omit .spec "type" }}{{- include "neo4j.services.extraSpec" . | nindent 2 }}{{- end }}
   selector:
     app: "{{ template "neo4j.name" $ }}"
-    helm.neo4j.com/instance: "{{ $.Release.Name }}"
+    helm.neo4j.com/instance: "{{ include "neo4j.fullname" $ }}"
   ports:
     - protocol: TCP
       port: 6362
@@ -115,11 +115,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ $.Release.Name }}-internals"
+  name: "{{ include "neo4j.fullname" $ }}-internals"
   namespace: "{{ $.Release.Namespace }}"
   labels:
     helm.neo4j.com/neo4j.name: "{{ template "neo4j.name" $ }}"
-    helm.neo4j.com/instance: "{{ $.Release.Name }}"
+    helm.neo4j.com/instance: "{{ include "neo4j.fullname" $ }}"
     app: "{{ template "neo4j.name" $ }}"
     helm.neo4j.com/clustering: "{{ $clusterEnabled }}"
     helm.neo4j.com/service: "internals"
@@ -133,7 +133,7 @@ spec:
   {{- with .spec }}{{ include "neo4j.services.extraSpec" . | nindent 2 }}{{ end }}
   selector:
     app: "{{ template "neo4j.name" $ }}"
-    helm.neo4j.com/instance: "{{ $.Release.Name }}"
+    helm.neo4j.com/instance: "{{ include "neo4j.fullname" $ }}"
   ports:
     - protocol: TCP
       port: 6362

--- a/neo4j/values.yaml
+++ b/neo4j/values.yaml
@@ -1,6 +1,11 @@
 # Default values for Neo4j.
 # This is a YAML-formatted file.
 
+## @param nameOverride String to partially override common.names.fullname
+nameOverride: ""
+## @param fullnameOverride String to fully override common.names.fullname
+fullnameOverride: ""
+
 neo4j:
   # Name of your cluster
   name: ""


### PR DESCRIPTION
Don't use .Release.Name for naming kubernetes objects as it causes issues when the chart is used as a dependency

#38
#76