### PR TITLE
[4.4] Implement nameOverrides and fullnameOverrides

### DIFF
--- a/internal/unit_tests/neo4j_configuration_test.go
+++ b/internal/unit_tests/neo4j_configuration_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/neo4j/helm-charts/internal/model"
 	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"os"
 	"strings"
@@ -111,6 +112,91 @@ func TestMetaspaceConfigs(t *testing.T) {
 		assert.Equal(t, userConfigMap.Data["dbms.memory.pagecache.size"], "74m")
 		assert.Equal(t, userConfigMap.Data["dbms.query_cache_size"], "10")
 
+	}
+
+	forEachPrimaryChart(t, andEachSupportedEdition(doTestCase))
+}
+func TestFullnameOverrideStatefulSet(t *testing.T) {
+	t.Parallel()
+
+	doTestCase := func(t *testing.T, chart model.Neo4jHelmChart, edition string) {
+		fullNameOverride := "use-this-name-instead"
+		manifest, err := model.HelmTemplate(t, chart, useDataModeAndAcceptLicense,
+			"--set", "fullnameOverride="+fullNameOverride,
+			"--set", "neo4j.edition="+edition,
+		)
+
+		if !assert.NoError(t, err) {
+			return
+		}
+		neo4jStatefulSet := manifest.First(&appsv1.StatefulSet{}).(*appsv1.StatefulSet)
+		assert.Equal(t, neo4jStatefulSet.GetName(), fullNameOverride)
+		assert.Equal(t, neo4jStatefulSet.Labels["helm.neo4j.com/instance"], fullNameOverride)
+		assert.Equal(t, neo4jStatefulSet.Spec.ServiceName, fullNameOverride)
+		assert.Equal(t, neo4jStatefulSet.Spec.Selector.MatchLabels["helm.neo4j.com/instance"], fullNameOverride)
+		assert.Equal(t, neo4jStatefulSet.Spec.Template.ObjectMeta.Labels["helm.neo4j.com/instance"], fullNameOverride)
+		assert.Contains(t, neo4jStatefulSet.Spec.Template.ObjectMeta.Annotations, fmt.Sprintf("checksum/%s-config", fullNameOverride))
+		neo4jContainer := neo4jStatefulSet.Spec.Template.Spec.Containers[0]
+		assert.Contains(t, neo4jContainer.EnvFrom, v1.EnvFromSource{
+			ConfigMapRef: &v1.ConfigMapEnvSource{
+				LocalObjectReference: v1.LocalObjectReference{Name: fmt.Sprintf("%s-env", fullNameOverride)},
+			},
+		})
+		assert.Contains(t, neo4jContainer.Env, v1.EnvVar{
+			Name:  "SERVICE_NEO4J_ADMIN",
+			Value: fmt.Sprintf("%s-admin.neo4j-my-release.svc.cluster.local", fullNameOverride),
+		})
+		assert.Contains(t, neo4jContainer.Env, v1.EnvVar{
+			Name:  "SERVICE_NEO4J_INTERNALS",
+			Value: fmt.Sprintf("%s-internals.neo4j-my-release.svc.cluster.local", fullNameOverride),
+		})
+		assert.Contains(t, neo4jContainer.Env, v1.EnvVar{
+			Name:  "SERVICE_NEO4J",
+			Value: fmt.Sprintf("%s.neo4j-my-release.svc.cluster.local", fullNameOverride),
+		})
+	}
+
+	forEachPrimaryChart(t, andEachSupportedEdition(doTestCase))
+}
+
+func TestNameOverrideStatefulSet(t *testing.T) {
+	t.Parallel()
+
+	doTestCase := func(t *testing.T, chart model.Neo4jHelmChart, edition string) {
+		nameOverride := "my-release-use-this-name-instead"
+		manifest, err := model.HelmTemplate(t, chart, useDataModeAndAcceptLicense,
+			"--set", "nameOverride=use-this-name-instead",
+			"--set", "neo4j.edition="+edition,
+		)
+
+		if !assert.NoError(t, err) {
+			return
+		}
+		neo4jStatefulSet := manifest.First(&appsv1.StatefulSet{}).(*appsv1.StatefulSet)
+		assert.Equal(t, neo4jStatefulSet.GetName(), nameOverride)
+		assert.Equal(t, neo4jStatefulSet.Labels["helm.neo4j.com/instance"], nameOverride)
+		assert.Equal(t, neo4jStatefulSet.Spec.ServiceName, nameOverride)
+		assert.Equal(t, neo4jStatefulSet.Spec.Selector.MatchLabels["helm.neo4j.com/instance"], nameOverride)
+		assert.Equal(t, neo4jStatefulSet.Spec.Template.ObjectMeta.Labels["helm.neo4j.com/instance"], nameOverride)
+		assert.Contains(t, neo4jStatefulSet.Spec.Template.ObjectMeta.Annotations, fmt.Sprintf("checksum/%s-config", nameOverride))
+		neo4jContainer := neo4jStatefulSet.Spec.Template.Spec.Containers[0]
+		assert.Contains(t, neo4jContainer.EnvFrom, v1.EnvFromSource{
+			ConfigMapRef: &v1.ConfigMapEnvSource{
+				LocalObjectReference: v1.LocalObjectReference{Name: fmt.Sprintf("%s-env", nameOverride)},
+			},
+		})
+		assert.Contains(t, neo4jContainer.Env, v1.EnvVar{
+			Name:  "SERVICE_NEO4J_ADMIN",
+			Value: fmt.Sprintf("%s-admin.neo4j-my-release.svc.cluster.local", nameOverride),
+		})
+		assert.Contains(t, neo4jContainer.Env, v1.EnvVar{
+			Name:  "SERVICE_NEO4J_INTERNALS",
+			Value: fmt.Sprintf("%s-internals.neo4j-my-release.svc.cluster.local", nameOverride),
+		})
+		assert.Contains(t, neo4jContainer.Env, v1.EnvVar{
+			Name:  "SERVICE_NEO4J",
+			Value: fmt.Sprintf("%s.neo4j-my-release.svc.cluster.local", nameOverride),
+		})
 	}
 
 	forEachPrimaryChart(t, andEachSupportedEdition(doTestCase))

--- a/neo4j-cluster-core/values.yaml
+++ b/neo4j-cluster-core/values.yaml
@@ -1,6 +1,11 @@
 # Default values for Neo4j.
 # This is a YAML-formatted file.
 
+## @param nameOverride String to partially override common.names.fullname
+nameOverride: ""
+## @param fullnameOverride String to fully override common.names.fullname
+fullnameOverride: ""
+
 neo4j:
   # A common name for all helm deployments that are part of the same Neo4j Cluster
   # To deploy multiple Neo4j clusters in the same Kubernetes namespace each Neo4j cluster should have a different name.

--- a/neo4j-cluster-read-replica/values.yaml
+++ b/neo4j-cluster-read-replica/values.yaml
@@ -1,6 +1,11 @@
 # Default values for Neo4j.
 # This is a YAML-formatted file.
 
+## @param nameOverride String to partially override common.names.fullname
+nameOverride: ""
+## @param fullnameOverride String to fully override common.names.fullname
+fullnameOverride: ""
+
 neo4j:
   # A common name for all helm deployments that are part of the same Neo4j Cluster
   # To deploy multiple Neo4j clusters in the same Kubernetes namespace each Neo4j cluster should have a different name.

--- a/neo4j-standalone/templates/_helpers.tpl
+++ b/neo4j-standalone/templates/_helpers.tpl
@@ -1,5 +1,25 @@
 {{/* vim: set filetype=mustache: */}}
 {{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "neo4j.fullname" -}}
+    {{- if .Values.fullnameOverride -}}
+        {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+    {{- else -}}
+        {{- if .Values.nameOverride -}}
+            {{- $name := default .Chart.Name .Values.nameOverride -}}
+            {{- if contains $name .Release.Name -}}
+                {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+            {{- else -}}
+                {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+            {{- end -}}
+       {{- else -}}
+            {{- printf "%s" .Release.Name | trunc 63 | trimSuffix "-" -}}
+       {{- end -}}
+    {{- end -}}
+{{- end -}}
+{{/*
 Convert a neo4j.conf properties text into valid yaml
 */}}
 {{- define "neo4j.configYaml" -}}
@@ -12,7 +32,8 @@ Convert a neo4j.conf properties text into valid yaml
 {{- end -}}
 
 {{- define "neo4j.appName" -}}
-  {{- .Values.neo4j.name | default .Release.Name }}
+  {{- $fullname := include "neo4j.fullname" .}}
+  {{- .Values.neo4j.name | default $fullname }}
 {{- end -}}
 
 {{- define "neo4j.cluster.server_groups" -}}

--- a/neo4j-standalone/templates/neo4j-config.yaml
+++ b/neo4j-standalone/templates/neo4j-config.yaml
@@ -5,7 +5,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "{{ .Release.Name }}-k8s-config"
+  name: "{{ include "neo4j.fullname" . }}-k8s-config"
   namespace: "{{ .Release.Namespace }}"
   labels:
     app: "{{ template "neo4j.appName" $ }}"
@@ -23,7 +23,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "{{ .Release.Name }}-user-config"
+  name: "{{ include "neo4j.fullname" . }}-user-config"
   namespace: "{{ .Release.Namespace }}"
   labels:
     app: "{{ template "neo4j.appName" $ }}"
@@ -64,7 +64,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "{{ .Release.Name }}-default-config"
+  name: "{{ include "neo4j.fullname" . }}-default-config"
   namespace: "{{ .Release.Namespace }}"
   labels:
     app: "{{ template "neo4j.appName" $ }}"
@@ -156,7 +156,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "{{ .Release.Name }}-apoc-config"
+  name: "{{ include "neo4j.fullname" . }}-apoc-config"
   namespace: "{{ .Release.Namespace }}"
   labels:
     app: "{{ template "neo4j.appName" $ }}"

--- a/neo4j-standalone/templates/neo4j-env.yaml
+++ b/neo4j-standalone/templates/neo4j-env.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "{{ .Release.Name }}-env"
+  name: "{{ include "neo4j.fullname" . }}-env"
   namespace: "{{ .Release.Namespace }}"
   labels:
     app: "{{ template "neo4j.appName" $ }}"
     {{- include "neo4j.labels" $.Values.neo4j | indent 4 }}
 data:
   # It should not be necessary for neo4j users/administrators to modify this configMap
-  # Neo4j configuration is set in the {{ .Release.Name }}-user-config ConfigMap
+  # Neo4j configuration is set in the {{ include "neo4j.fullname" . }}-user-config ConfigMap
   {{- if eq .Values.neo4j.acceptLicenseAgreement "yes" }}
   NEO4J_ACCEPT_LICENSE_AGREEMENT: "yes"
   {{- end }}

--- a/neo4j-standalone/templates/neo4j-loadbalancer.yaml
+++ b/neo4j-standalone/templates/neo4j-loadbalancer.yaml
@@ -10,7 +10,8 @@
 {{- $ignored = set $values.selector "helm.neo4j.com/neo4j.name" ( include "neo4j.name" $ ) }}
 {{- $ignored = set $values.selector "helm.neo4j.com/dbms.mode" ( index $.Values.config "dbms.mode" | default "CORE" | upper ) }}
 {{- else }}
-{{- $ignored = set $values.selector "helm.neo4j.com/instance" $.Release.Name }}
+{{- $fullname := include "neo4j.fullname" $ }}
+{{- $ignored = set $values.selector "helm.neo4j.com/instance" $fullname }}
 {{- end }}
 {{- dict "Release" $.Release "Values" $values | include "neo4j.services.neo4j" }}
 {{- end }}

--- a/neo4j-standalone/templates/neo4j-service-account.yaml
+++ b/neo4j-standalone/templates/neo4j-service-account.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   namespace: "{{ .Release.Namespace }}"
-  name: {{ .Release.Name }}
+  name: {{ include "neo4j.fullname" . }}
   labels:
     app: "{{ template "neo4j.appName" $ }}"
     {{- include "neo4j.labels" $.Values.neo4j | indent 4 }}
@@ -13,7 +13,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   namespace: "{{ .Release.Namespace }}"
-  name: "{{ .Release.Name }}-service-reader"
+  name: "{{ include "neo4j.fullname" . }}-service-reader"
   labels:
     app: "{{ template "neo4j.appName" $ }}"
     {{- include "neo4j.labels" $.Values.neo4j | indent 4 }}
@@ -26,16 +26,16 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   namespace: "{{ .Release.Namespace }}"
-  name: "{{ .Release.Name }}-service-binding"
+  name: "{{ include "neo4j.fullname" . }}-service-binding"
   labels:
     app: "{{ template "neo4j.appName" $ }}"
     {{- include "neo4j.labels" $.Values.neo4j | indent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: {{ .Release.Name }}
+    name: {{ include "neo4j.fullname" . }}
 roleRef:
   # "roleRef" specifies the binding to a Role / ClusterRole
   kind: Role # this must be Role or ClusterRole
-  name: {{ .Release.Name }}-service-reader # this must match the name of the Role or ClusterRole you wish to bind to
+  name: {{ include "neo4j.fullname" . }}-service-reader # this must match the name of the Role or ClusterRole you wish to bind to
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/neo4j-standalone/templates/neo4j-statefulset.yaml
+++ b/neo4j-standalone/templates/neo4j-statefulset.yaml
@@ -16,22 +16,22 @@ metadata:
     helm.neo4j.com/neo4j.name: "{{ template "neo4j.name" $ }}"
     helm.neo4j.com/dbms.mode: "{{ index $.Values.config "dbms.mode" | default "SINGLE" | upper }}"
     app: "{{ template "neo4j.appName" . }}"
-    helm.neo4j.com/instance: "{{ .Release.Name }}"
+    helm.neo4j.com/instance: {{ include "neo4j.fullname" . }}
     {{- include "neo4j.labels" $.Values.neo4j | indent 4 }}
-  name: "{{ .Release.Name }}"
+  name: {{ include "neo4j.fullname" . }}
   namespace: "{{ .Release.Namespace }}"
   {{- if not (empty $.Values.statefulset.metadata.annotations) }}
   annotations:
     {{- include "neo4j.annotations" $.Values.statefulset.metadata.annotations | indent 4 }}
   {{- end }}
 spec:
-  serviceName: "{{ .Release.Name }}"
+  serviceName: "{{ include "neo4j.fullname" . }}"
   podManagementPolicy: "Parallel" # This setting means that the StatefulSet controller doesn't block applying changes until the existing Pod is READY.
   replicas: 1
   selector:
     matchLabels:
       app: "{{ template "neo4j.appName" . }}"
-      helm.neo4j.com/instance: "{{ .Release.Name }}"
+      helm.neo4j.com/instance: "{{ include "neo4j.fullname" . }}"
   template:
     metadata:
       labels:
@@ -40,15 +40,15 @@ spec:
         helm.neo4j.com/dbms.mode: "{{ index $.Values.config "dbms.mode" | default "SINGLE" | upper }}"
         helm.neo4j.com/pod_category: "neo4j-instance" # used for anti affinity rules
         helm.neo4j.com/neo4j.loadbalancer: "{{ $.Values.podSpec.loadbalancer }}"
-        helm.neo4j.com/instance: "{{ .Release.Name }}"
+        helm.neo4j.com/instance: "{{ include "neo4j.fullname" . }}"
         {{- include "neo4j.labels" $.Values.neo4j | indent 8 }}
       annotations:
-        "checksum/{{ .Release.Name }}-config": {{ include (print $.Template.BasePath "/neo4j-config.yaml") . | sha256sum }}
+        "checksum/{{ include "neo4j.fullname" . }}-config": {{ include (print $.Template.BasePath "/neo4j-config.yaml") . | sha256sum }}
         {{- include "neo4j.annotations" $.Values.podSpec.annotations | indent 8 }}
     spec:
       {{- include "neo4j.affinity" . | indent 6 }}
       {{- if $.Values.podSpec.serviceAccountName | or $clusterEnabled }}
-      serviceAccountName: "{{ if kindIs "string" $.Values.podSpec.serviceAccountName | and $.Values.podSpec.serviceAccountName }}{{ $.Values.podSpec.serviceAccountName }}{{ else }}{{ .Release.Name }}{{ end }}"
+      serviceAccountName: "{{ if kindIs "string" $.Values.podSpec.serviceAccountName | and $.Values.podSpec.serviceAccountName }}{{ $.Values.podSpec.serviceAccountName }}{{ else }}{{ include "neo4j.fullname" . }}{{ end }}"
       {{- end }}
       securityContext: {{ toYaml .Values.securityContext | nindent 8 }}
       {{- include "neo4j.priorityClassName" . | nindent 6 }}
@@ -85,7 +85,7 @@ spec:
           {{- end }}
           envFrom:
             - configMapRef:
-                name: "{{ .Release.Name }}-env"
+                name: "{{ include "neo4j.fullname" . }}-env"
             {{- if not $authDisabled }}
             - secretRef:
                 name: "{{ template "neo4j.appName" . }}-auth"
@@ -100,11 +100,11 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: SERVICE_NEO4J_ADMIN
-              value: "{{ .Release.Name }}-admin.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+              value: "{{ include "neo4j.fullname" . }}-admin.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
             - name: SERVICE_NEO4J_INTERNALS
-              value: "{{ .Release.Name }}-internals.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+              value: "{{ include "neo4j.fullname" . }}-internals.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
             - name: SERVICE_NEO4J
-              value: "{{ .Release.Name }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+              value: "{{ include "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
           ports:
             - containerPort: 7474
               name: http
@@ -176,11 +176,11 @@ spec:
             defaultMode: 0440
             sources:
               - configMap:
-                  name: "{{ .Release.Name }}-default-config"
+                  name: "{{ include "neo4j.fullname" . }}-default-config"
               - configMap:
-                  name: "{{ .Release.Name }}-user-config"
+                  name: "{{ include "neo4j.fullname" . }}-user-config"
               - configMap:
-                  name: "{{ .Release.Name }}-k8s-config"
+                  name: "{{ include "neo4j.fullname" . }}-k8s-config"
         {{- include "neo4j.additionalVolumes" .Values.additionalVolumes | nindent 8 }}
         {{- include "neo4j.apoc.volume" . | nindent 8 }}
         {{- with include "neo4j.ssl.volumesFromSecrets" .Values.ssl }}{{ nindent 8 .}}{{ end -}}

--- a/neo4j-standalone/templates/neo4j-svc.yaml
+++ b/neo4j-standalone/templates/neo4j-svc.yaml
@@ -15,12 +15,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ $.Release.Name }}"
+  name: "{{ include "neo4j.fullname" . }}"
   namespace: "{{ $.Release.Namespace }}"
   labels:
     helm.neo4j.com/neo4j.name: "{{ template "neo4j.name" $ }}"
     app: "{{ template "neo4j.appName" $ }}"
-    helm.neo4j.com/instance: "{{ $.Release.Name }}"
+    helm.neo4j.com/instance: "{{ include "neo4j.fullname" . }}"
     helm.neo4j.com/service: "default"
     {{- include "neo4j.labels" $.Values.neo4j | indent 4 }}
   {{- with .Values.services.default.annotations }}
@@ -32,7 +32,7 @@ spec:
   {{- with .spec }}{{- include "neo4j.services.extraSpec" . | nindent 2 }}{{- end }}
   selector:
     app: "{{ template "neo4j.appName" $ }}"
-    helm.neo4j.com/instance: "{{ $.Release.Name }}"
+    helm.neo4j.com/instance: "{{ include "neo4j.fullname" . }}"
   ports:
     - protocol: TCP
       port: 7687
@@ -53,12 +53,12 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ $.Release.Name }}-admin"
+  name: "{{ include "neo4j.fullname" $ }}-admin"
   namespace: "{{ $.Release.Namespace }}"
   labels:
     helm.neo4j.com/neo4j.name: "{{ template "neo4j.name" $ }}"
     app: "{{ template "neo4j.appName" $ }}"
-    helm.neo4j.com/instance: "{{ $.Release.Name }}"
+    helm.neo4j.com/instance: "{{ include "neo4j.fullname" $ }}"
     helm.neo4j.com/service: "admin"
     {{- include "neo4j.labels" $.Values.neo4j | indent 4 }}
   {{- with .annotations }}
@@ -70,7 +70,7 @@ spec:
   {{- with omit .spec "type" }}{{- include "neo4j.services.extraSpec" . | nindent 2 }}{{- end }}
   selector:
     app: "{{ template "neo4j.appName" $ }}"
-    helm.neo4j.com/instance: "{{ $.Release.Name }}"
+    helm.neo4j.com/instance: "{{ include "neo4j.fullname" $ }}"
   ports:
     - protocol: TCP
       port: 6362
@@ -116,11 +116,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ $.Release.Name }}-internals"
+  name: "{{ include "neo4j.fullname" $ }}-internals"
   namespace: "{{ $.Release.Namespace }}"
   labels:
     helm.neo4j.com/neo4j.name: "{{ template "neo4j.name" $ }}"
-    helm.neo4j.com/instance: "{{ $.Release.Name }}"
+    helm.neo4j.com/instance: "{{ include "neo4j.fullname" $ }}"
     app: "{{ template "neo4j.appName" $ }}"
     helm.neo4j.com/dbms.mode: "{{ index $.Values.config "dbms.mode" | default "SINGLE" | upper }}"
     helm.neo4j.com/service: "internals"
@@ -134,7 +134,7 @@ spec:
   {{- with .spec }}{{ include "neo4j.services.extraSpec" . | nindent 2 }}{{ end }}
   selector:
     app: "{{ template "neo4j.appName" $ }}"
-    helm.neo4j.com/instance: "{{ $.Release.Name }}"
+    helm.neo4j.com/instance: "{{ include "neo4j.fullname" $ }}"
   ports:
     - protocol: TCP
       port: 6362

--- a/neo4j-standalone/values.yaml
+++ b/neo4j-standalone/values.yaml
@@ -1,6 +1,11 @@
 # Default values for Neo4j.
 # This is a YAML-formatted file.
 
+## @param nameOverride String to partially override common.names.fullname
+nameOverride: ""
+## @param fullnameOverride String to fully override common.names.fullname
+fullnameOverride: ""
+
 neo4j:
   # Name of your cluster
   name: ""


### PR DESCRIPTION
Don't use .Release.Name for naming kubernetes objects as it causes issues when the chart is used as a dependency

#38
#76
