### PR TITLE
Start Read Replica when maintenance mode is true regardless of the state of the core (primary) cluster

### DIFF
--- a/neo4j-standalone/templates/_helpers.tpl
+++ b/neo4j-standalone/templates/_helpers.tpl
@@ -131,7 +131,9 @@ If no password is set in `Values.neo4j.password` generates a new random password
     {{- end -}}
 
     {{- if lt (len $clusterList) 3 -}}
-        {{ fail "Cannot install Read Replica until a cluster of 3 or more cores is formed" }}
+        {{- if not .Values.neo4j.offlineMaintenanceModeEnabled  -}}
+          {{ fail "Cannot install Read Replica until a cluster of 3 or more cores is formed" }}
+        {{- end -}}
     {{- end -}}
 
 {{- end -}}


### PR DESCRIPTION
This adds a test to see if offlineMaintenanceMode is false when testing for a running cluster of at least 3.  If offlineMaintenanceMode is true - the fail is not encountered and the Read Replica will start.
This is crucial to ease fixing a Neo4j cluster that has encountered a severe problem, such as out of disk space.