### PR TITLE
Add new configuration value `neo4j.passwordFromSecretLookup`

### DIFF
--- a/internal/integration_tests/auth_test.go
+++ b/internal/integration_tests/auth_test.go
@@ -92,11 +92,12 @@ func TestAuthSecretsWithLookupDisabled(t *testing.T) {
 	}
 	namespace := string(releaseName.Namespace())
 
-	helmClient := model.NewHelmClient(model.DefaultNeo4jChartName)
+	helmClient := model.NewHelmClient(model.DefaultNeo4jChartName, "--dry-run")
 	helmValues := model.DefaultEnterpriseValues
 	helmValues.Neo4J.Edition = model.Neo4jEdition
 	helmValues.Neo4J.PasswordFromSecret = "missing-secret"
-	helmValues.Neo4J.PasswordFromSecretLookup = false
+	secretLookup := false
+	helmValues.Neo4J.PasswordFromSecretLookup = &secretLookup
 	_, err = helmClient.Install(t, releaseName.String(), namespace, helmValues)
 	assert.NoError(t, err)
 	t.Cleanup(func() {

--- a/internal/integration_tests/auth_test.go
+++ b/internal/integration_tests/auth_test.go
@@ -83,6 +83,29 @@ func TestAuthSecretsInvalidPassword(t *testing.T) {
 	})
 }
 
+func TestAuthSecretsWithLookupDisabled(t *testing.T) {
+	t.Parallel()
+	releaseName := model.NewReleaseName("auth-invalid-password-" + TestRunIdentifier)
+	_, err := createNamespace(t, releaseName)
+	if err != nil {
+		return
+	}
+	namespace := string(releaseName.Namespace())
+
+	helmClient := model.NewHelmClient(model.DefaultNeo4jChartName)
+	helmValues := model.DefaultEnterpriseValues
+	helmValues.Neo4J.Edition = model.Neo4jEdition
+	helmValues.Neo4J.PasswordFromSecret = "missing-secret"
+	helmValues.Neo4J.PasswordFromSecretLookup = false
+	_, err = helmClient.Install(t, releaseName.String(), namespace, helmValues)
+	assert.NoError(t, err)
+	t.Cleanup(func() {
+		_ = runAll(t, "kubectl", [][]string{
+			{"delete", "namespace", string(releaseName.Namespace())},
+		}, false)
+	})
+}
+
 func TestAuthPasswordCannotBeDifferent(t *testing.T) {
 	if model.Neo4jEdition != "enterprise" {
 		t.Skip()

--- a/internal/model/helm.go
+++ b/internal/model/helm.go
@@ -22,14 +22,16 @@ import (
 type HelmClient struct {
 	chartName string
 	chartPath string
+	extraArgs []string
 }
 
-func NewHelmClient(chartName string) *HelmClient {
+func NewHelmClient(chartName string, extraArgs ...string) *HelmClient {
 	var _, sourceFile, _, _ = runtime.Caller(0)
 	var sourceDir = path.Dir(sourceFile)
 	return &HelmClient{
 		chartName: chartName,
 		chartPath: path.Join(path.Join(sourceDir, "../.."), chartName),
+		extraArgs: extraArgs,
 	}
 }
 
@@ -242,6 +244,7 @@ func (c *HelmClient) Install(t *testing.T, releaseName string, namespace string,
 		"--values",
 		"-",
 	}
+	helmArgs = append(helmArgs, c.extraArgs...)
 	cmd := exec.Command("helm", helmArgs...)
 	stdin, err := cmd.StdinPipe()
 	if err != nil {

--- a/internal/model/release_values.go
+++ b/internal/model/release_values.go
@@ -34,7 +34,7 @@ type Neo4J struct {
 	Name                          string      `yaml:"name,omitempty"`
 	Password                      string      `yaml:"password,omitempty"`
 	PasswordFromSecret            string      `yaml:"passwordFromSecret,omitempty"`
-	PasswordFromSecretLookup      bool        `yaml:"passwordFromSecretLookup,omitempty"`
+	PasswordFromSecretLookup      *bool       `yaml:"passwordFromSecretLookup,omitempty"`
 	Edition                       string      `yaml:"edition,omitempty"`
 	MinimumClusterSize            int         `yaml:"minimumClusterSize,omitempty"`
 	AcceptLicenseAgreement        string      `yaml:"acceptLicenseAgreement,omitempty"`

--- a/internal/model/release_values.go
+++ b/internal/model/release_values.go
@@ -34,6 +34,7 @@ type Neo4J struct {
 	Name                          string      `yaml:"name,omitempty"`
 	Password                      string      `yaml:"password,omitempty"`
 	PasswordFromSecret            string      `yaml:"passwordFromSecret,omitempty"`
+	PasswordFromSecretLookup      bool        `yaml:"passwordFromSecretLookup,omitempty"`
 	Edition                       string      `yaml:"edition,omitempty"`
 	MinimumClusterSize            int         `yaml:"minimumClusterSize,omitempty"`
 	AcceptLicenseAgreement        string      `yaml:"acceptLicenseAgreement,omitempty"`

--- a/neo4j/templates/_helpers.tpl
+++ b/neo4j/templates/_helpers.tpl
@@ -331,18 +331,19 @@ affinity:
 
 {{- define "neo4j.secretName" -}}
     {{- if .Values.neo4j.passwordFromSecret -}}
-        {{- $secret := (lookup "v1" "Secret" .Release.Namespace .Values.neo4j.passwordFromSecret) }}
-        {{- $secretExists := $secret | all }}
-        {{- if not ( $secretExists ) -}}
-            {{ fail (printf "Secret %s configured in 'neo4j.passwordFromSecret' not found" .Values.neo4j.passwordFromSecret) }}
-        {{- else if not (hasKey $secret.data "NEO4J_AUTH") -}}
-            {{ fail (printf "Secret %s must contain key NEO4J_DATA" .Values.neo4j.passwordFromSecret) }}
-        {{/*The secret must start with characters 'neo4j/`*/}}
-        {{- else if not (index $secret.data "NEO4J_AUTH" | b64dec | regexFind "^neo4j\\/\\w*") -}}
-            {{ fail (printf "Password in secret %s must start with the characters 'neo4j/'" .Values.neo4j.passwordFromSecret) }}
-        {{- else -}}
+        {{- if .Values.neo4j.passwordFromSecretLookup -}}
+            {{- $secret := (lookup "v1" "Secret" .Release.Namespace .Values.neo4j.passwordFromSecret) }}
+            {{- $secretExists := $secret | all }}
+            {{- if not ( $secretExists ) -}}
+                {{ fail (printf "Secret %s configured in 'neo4j.passwordFromSecret' not found" .Values.neo4j.passwordFromSecret) }}
+            {{- else if not (hasKey $secret.data "NEO4J_AUTH") -}}
+                {{ fail (printf "Secret %s must contain key NEO4J_DATA" .Values.neo4j.passwordFromSecret) }}
+            {{/*The secret must start with characters 'neo4j/`*/}}
+            {{- else if not (index $secret.data "NEO4J_AUTH" | b64dec | regexFind "^neo4j\\/\\w*") -}}
+                {{ fail (printf "Password in secret %s must start with the characters 'neo4j/'" .Values.neo4j.passwordFromSecret) }}
+        {{- end -}}
             {{- printf "%s" (tpl .Values.neo4j.passwordFromSecret $) -}}
-         {{- end -}}
+        {{- end -}}
     {{- else -}}
         {{- include "neo4j.name" . | printf "%s-auth" -}}
     {{- end -}}

--- a/neo4j/templates/_helpers.tpl
+++ b/neo4j/templates/_helpers.tpl
@@ -341,9 +341,9 @@ affinity:
             {{/*The secret must start with characters 'neo4j/`*/}}
             {{- else if not (index $secret.data "NEO4J_AUTH" | b64dec | regexFind "^neo4j\\/\\w*") -}}
                 {{ fail (printf "Password in secret %s must start with the characters 'neo4j/'" .Values.neo4j.passwordFromSecret) }}
+            {{- end -}}
         {{- end -}}
-            {{- printf "%s" (tpl .Values.neo4j.passwordFromSecret $) -}}
-        {{- end -}}
+        {{- printf "%s" (tpl .Values.neo4j.passwordFromSecret $) -}}
     {{- else -}}
         {{- include "neo4j.name" . | printf "%s-auth" -}}
     {{- end -}}

--- a/neo4j/values.yaml
+++ b/neo4j/values.yaml
@@ -15,6 +15,9 @@ neo4j:
 
   # Existing secret to use for initial database password
   passwordFromSecret: ""
+  # If true then install will fail if the secret set in passwordFromSecret is missing. Set to false when deploying with
+  # ArgoCD because lookup does not work correctly.
+  passwordFromSecretLookup: true
   # Neo4j Edition to use (community|enterprise)
   edition: "community"
 


### PR DESCRIPTION
Tools such as ArgoCD perform `helm template` to deploy the chart and the secret lookup fails. Add an option to disable the lookup for these situations

#127
