### PR TITLE
[4.4] Add new configuration value `neo4j.passwordFromSecretLookup`

### DIFF
--- a/internal/integration_tests/auth_test.go
+++ b/internal/integration_tests/auth_test.go
@@ -83,6 +83,30 @@ func TestAuthSecretsInvalidPassword(t *testing.T) {
 	})
 }
 
+func TestAuthSecretsWithLookupDisabled(t *testing.T) {
+	t.Parallel()
+	releaseName := model.NewReleaseName("auth-invalid-password-" + TestRunIdentifier)
+	_, err := createNamespace(t, releaseName)
+	if err != nil {
+		return
+	}
+	namespace := string(releaseName.Namespace())
+
+	helmClient := model.NewHelmClient(model.Neo4jStandaloneChartName, "--dry-run")
+	helmValues := model.DefaultEnterpriseValues
+	helmValues.Neo4J.Edition = model.Neo4jEdition
+	helmValues.Neo4J.PasswordFromSecret = "missing-secret"
+	secretLookup := false
+	helmValues.Neo4J.PasswordFromSecretLookup = &secretLookup
+	_, err = helmClient.Install(t, releaseName.String(), namespace, helmValues)
+	assert.NoError(t, err)
+	t.Cleanup(func() {
+		_ = runAll(t, "kubectl", [][]string{
+			{"delete", "namespace", string(releaseName.Namespace())},
+		}, false)
+	})
+}
+
 func TestAuthPasswordCannotBeDifferent(t *testing.T) {
 	if model.Neo4jEdition != "enterprise" {
 		t.Skip()

--- a/internal/model/helm.go
+++ b/internal/model/helm.go
@@ -22,14 +22,16 @@ import (
 type HelmClient struct {
 	chartName string
 	chartPath string
+	extraArgs []string
 }
 
-func NewHelmClient(chartName string) *HelmClient {
+func NewHelmClient(chartName string, extraArgs ...string) *HelmClient {
 	var _, sourceFile, _, _ = runtime.Caller(0)
 	var sourceDir = path.Dir(sourceFile)
 	return &HelmClient{
 		chartName: chartName,
 		chartPath: path.Join(path.Join(sourceDir, "../.."), chartName),
+		extraArgs: extraArgs,
 	}
 }
 
@@ -203,6 +205,7 @@ func (c *HelmClient) Install(t *testing.T, releaseName string, namespace string,
 		"--values",
 		"-",
 	}
+	helmArgs = append(helmArgs, c.extraArgs...)
 	cmd := exec.Command("helm", helmArgs...)
 	stdin, err := cmd.StdinPipe()
 	if err != nil {

--- a/internal/model/release_values.go
+++ b/internal/model/release_values.go
@@ -33,6 +33,7 @@ type Neo4J struct {
 	Name                          string      `yaml:"name,omitempty"`
 	Password                      string      `yaml:"password,omitempty"`
 	PasswordFromSecret            string      `yaml:"passwordFromSecret,omitempty"`
+	PasswordFromSecretLookup      *bool       `yaml:"passwordFromSecretLookup,omitempty"`
 	Edition                       string      `yaml:"edition,omitempty"`
 	AcceptLicenseAgreement        string      `yaml:"acceptLicenseAgreement,omitempty"`
 	OfflineMaintenanceModeEnabled bool        `yaml:"offlineMaintenanceModeEnabled,omitempty"`

--- a/internal/unit_tests/helm_template_primaries_test.go
+++ b/internal/unit_tests/helm_template_primaries_test.go
@@ -495,6 +495,42 @@ func TestAuthSecrets(t *testing.T) {
 	}))
 }
 
+func TestPasswordFromExistingSecretWithLookupDisabled(t *testing.T) {
+	t.Parallel()
+
+	forEachPrimaryChart(t, andEachSupportedEdition(func(t *testing.T, chart model.Neo4jHelmChart, edition string) {
+		helmValues := model.DefaultEnterpriseValues
+		helmValues.Neo4J.Edition = edition
+		helmValues.Neo4J.PasswordFromSecret = "test-secret"
+		passwordLookup := false
+		helmValues.Neo4J.PasswordFromSecretLookup = &passwordLookup
+
+		helmArgs := []string{
+			"--set", "neo4j.edition=" + edition,
+		}
+		if edition == "enterprise" {
+			helmArgs = append(helmArgs, "--set", "neo4j.acceptLicenseAgreement=yes")
+		}
+		helmArgs = append(helmArgs, "--set", "neo4j.passwordFromSecret=test-secret")
+		helmArgs = append(helmArgs, "--set", "neo4j.passwordFromSecretLookup=false")
+
+		manifest, err := model.HelmTemplate(t, chart, requiredDataMode, helmArgs...)
+		if !assert.NoError(t, err) {
+			return
+		}
+		statefulSet := manifest.OfTypeWithName(&appsv1.StatefulSet{}, model.DefaultHelmTemplateReleaseName.String())
+		if !assert.NotNil(t, statefulSet, fmt.Sprintf("no statefulset found with name %s", model.DefaultHelmTemplateReleaseName)) {
+			return
+		}
+		neo4jContainer := statefulSet.(*appsv1.StatefulSet).Spec.Template.Spec.Containers[0]
+		assert.Contains(t, neo4jContainer.EnvFrom, v1.EnvFromSource{
+			SecretRef: &v1.SecretEnvSource{
+				LocalObjectReference: v1.LocalObjectReference{Name: "test-secret"},
+			},
+		})
+	}))
+}
+
 func TestDefaultLabels(t *testing.T) {
 	t.Parallel()
 

--- a/neo4j-cluster-core/values.yaml
+++ b/neo4j-cluster-core/values.yaml
@@ -15,6 +15,9 @@ neo4j:
   password: ""
   # Existing secret to use for initial database password
   passwordFromSecret: ""
+  # If true then install will fail if the secret set in passwordFromSecret is missing. Set to false when deploying with
+  # ArgoCD because lookup does not work correctly.
+  passwordFromSecretLookup: true
   # Neo4j Clustering requires Enterprise Edition
   edition: "enterprise"
 

--- a/neo4j-standalone/templates/_helpers.tpl
+++ b/neo4j-standalone/templates/_helpers.tpl
@@ -374,18 +374,19 @@ affinity:
 
 {{- define "neo4j.secretName" -}}
     {{- if .Values.neo4j.passwordFromSecret -}}
-        {{- $secret := (lookup "v1" "Secret" .Release.Namespace .Values.neo4j.passwordFromSecret) }}
-        {{- $secretExists := $secret | all }}
-        {{- if not ( $secretExists ) -}}
-            {{ fail (printf "Secret %s configured in 'neo4j.passwordFromSecret' not found" .Values.neo4j.passwordFromSecret) }}
-        {{- else if not (hasKey $secret.data "NEO4J_AUTH") -}}
-            {{ fail (printf "Secret %s must contain key NEO4J_DATA" .Values.neo4j.passwordFromSecret) }}
-        {{/*The secret must start with characters 'neo4j/`*/}}
-        {{- else if not (index $secret.data "NEO4J_AUTH" | b64dec | regexFind "^neo4j\\/\\w*") -}}
-            {{ fail (printf "Password in secret %s must start with the characters 'neo4j/'" .Values.neo4j.passwordFromSecret) }}
-        {{- else -}}
-            {{- printf "%s" (tpl .Values.neo4j.passwordFromSecret $) -}}
-         {{- end -}}
+        {{- if .Values.neo4j.passwordFromSecretLookup -}}
+            {{- $secret := (lookup "v1" "Secret" .Release.Namespace .Values.neo4j.passwordFromSecret) }}
+            {{- $secretExists := $secret | all }}
+            {{- if not ( $secretExists ) -}}
+                {{ fail (printf "Secret %s configured in 'neo4j.passwordFromSecret' not found" .Values.neo4j.passwordFromSecret) }}
+            {{- else if not (hasKey $secret.data "NEO4J_AUTH") -}}
+                {{ fail (printf "Secret %s must contain key NEO4J_DATA" .Values.neo4j.passwordFromSecret) }}
+            {{/*The secret must start with characters 'neo4j/`*/}}
+            {{- else if not (index $secret.data "NEO4J_AUTH" | b64dec | regexFind "^neo4j\\/\\w*") -}}
+                {{ fail (printf "Password in secret %s must start with the characters 'neo4j/'" .Values.neo4j.passwordFromSecret) }}
+            {{- end -}}
+        {{- end -}}
+        {{- printf "%s" (tpl .Values.neo4j.passwordFromSecret $) -}}
     {{- else -}}
         {{- include "neo4j.name" . | printf "%s-auth" -}}
     {{- end -}}

--- a/neo4j-standalone/values.yaml
+++ b/neo4j-standalone/values.yaml
@@ -15,6 +15,9 @@ neo4j:
 
   # Existing secret to use for initial database password
   passwordFromSecret: ""
+  # If true then install will fail if the secret set in passwordFromSecret is missing. Set to false when deploying with
+  # ArgoCD because lookup does not work correctly.
+  passwordFromSecretLookup: true
   # Neo4j Edition to use (community|enterprise)
   edition: "community"
   # set edition: "enterprise" to use Neo4j Enterprise Edition


### PR DESCRIPTION
Tools such as ArgoCD perform `helm template` to deploy the chart and the secret lookup fails. Add an option to disable the lookup for these situations

#127
