### PR TITLE
Added nodeSelectorLookup flag to allow users to disable lookup

### DIFF
--- a/internal/model/helm.go
+++ b/internal/model/helm.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	. "github.com/neo4j/helm-charts/internal/helpers"
 	"github.com/neo4j/helm-charts/internal/resources"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	"io"
 	"io/ioutil"
 	"k8s.io/utils/env"
@@ -211,9 +211,12 @@ func HelmReleaseValues(t *testing.T) (HelmValues, error) {
 	return releaseValues, err
 }
 
-func HelmTemplateFromStruct(t *testing.T, chart HelmChartBuilder, values HelmValues) (*K8sResources, error) {
+func HelmTemplateFromStruct(t *testing.T, chart HelmChartBuilder, values HelmValues, extraArgs ...string) (*K8sResources, error) {
 	helmValues, _ := yaml.Marshal(values)
 	args := append(minHelmCommand("template", &DefaultHelmTemplateReleaseName, chart), "--values", "-")
+	if len(extraArgs) > 0 {
+		args = append(args, extraArgs...)
+	}
 	cmd := exec.Command("helm", args...)
 	stdin, err := cmd.StdinPipe()
 	if err != nil {

--- a/internal/model/release_values.go
+++ b/internal/model/release_values.go
@@ -9,7 +9,8 @@ type HelmValues struct {
 	Volumes                Volumes           `yaml:"volumes,omitempty"`
 	AdditionalVolumes      []interface{}     `yaml:"additionalVolumes,omitempty"`
 	AdditionalVolumeMounts []interface{}     `yaml:"additionalVolumeMounts,omitempty"`
-	NodeSelector           v1.NodeSelector   `yaml:"nodeSelector,omitempty"`
+	NodeSelector           map[string]string `yaml:"nodeSelector,omitempty"`
+	NodeSelectorLookup     bool              `default:"true" yaml:"nodeSelectorLookup"`
 	Services               Services          `yaml:"services,omitempty"`
 	Config                 map[string]string `yaml:"config,omitempty"`
 	SecurityContext        SecurityContext   `yaml:"securityContext,omitempty"`
@@ -110,8 +111,6 @@ type Volumes struct {
 	Metrics  Metrics  `yaml:"metrics,omitempty"`
 	Import   Import   `yaml:"import,omitempty"`
 	Licenses Licenses `yaml:"licenses,omitempty"`
-}
-type NodeSelector struct {
 }
 type Annotations struct {
 }

--- a/internal/unit_tests/helm_template_primaries_test.go
+++ b/internal/unit_tests/helm_template_primaries_test.go
@@ -1181,6 +1181,46 @@ func TestInvalidNodeSelectorLabels(t *testing.T) {
 	}))
 }
 
+// TestNodeSelectorLabelsWithLookupDisabled tests nodeSelectorLookup flag when set to false
+func TestNodeSelectorLabelsWithLookupDisabled(t *testing.T) {
+	t.Parallel()
+	helmValues := model.DefaultCommunityValues
+	helmValues.NodeSelectorLookup = false
+	helmValues.NodeSelector = map[string]string{
+		"label1": "value1",
+	}
+
+	forEachSupportedEdition(t, model.Neo4jHelmChartCommunityAndEnterprise, func(t *testing.T, chart model.Neo4jHelmChartBuilder, edition string) {
+		if edition == "enterprise" {
+			helmValues = model.DefaultEnterpriseValues
+		}
+		_, err := model.HelmTemplateFromStruct(t, chart, helmValues)
+		if !assert.NoError(t, err) {
+			return
+		}
+	})
+}
+
+// TestNodeSelectorLabelsWithLookupDisabledWithDryRun tests nodeSelectorLookup flag when set to false along with --dry-run flag
+func TestNodeSelectorLabelsWithLookupDisabledWithDryRun(t *testing.T) {
+	t.Parallel()
+	helmValues := model.DefaultCommunityValues
+	helmValues.NodeSelectorLookup = false
+	helmValues.NodeSelector = map[string]string{
+		"label1": "value1",
+	}
+
+	forEachSupportedEdition(t, model.Neo4jHelmChartCommunityAndEnterprise, func(t *testing.T, chart model.Neo4jHelmChartBuilder, edition string) {
+		if edition == "enterprise" {
+			helmValues = model.DefaultEnterpriseValues
+		}
+		_, err := model.HelmTemplateFromStruct(t, chart, helmValues, "--dry-run")
+		if !assert.NoError(t, err) {
+			return
+		}
+	})
+}
+
 // TestAdditionalVolumesAndMounts checks if the additionalVolumes and additionalVolumeMounts are present or not
 func TestAdditionalVolumesAndMounts(t *testing.T) {
 	t.Parallel()

--- a/neo4j/templates/_helpers.tpl
+++ b/neo4j/templates/_helpers.tpl
@@ -55,7 +55,7 @@ Convert a neo4j.conf properties text into valid yaml
 
 {{/* checkNodeSelectorLabels checks if there is any node in the cluster which has nodeSelector labels */}}
 {{- define "neo4j.checkNodeSelectorLabels" -}}
-    {{- if not (empty $.Values.nodeSelector) -}}
+    {{- if and (not (empty $.Values.nodeSelector)) $.Values.nodeSelectorLookup -}}
         {{- $validNodes := 0 -}}
         {{- $numberOfLabelsRequired := len $.Values.nodeSelector -}}
         {{- range $index, $node := (lookup "v1" "Node" .Release.Namespace "").items -}}

--- a/neo4j/values.yaml
+++ b/neo4j/values.yaml
@@ -154,8 +154,15 @@ additionalVolumeMounts: []
 #nodeSelector labels
 #please ensure the respective labels are present on one of the cluster nodes or else helm charts will throw an error
 nodeSelector: {}
-#  "label1: "value1"
-#  "label2: "value2"
+#  label1: "value1"
+#  label2: "value2"
+
+#make it false if you want the nodeSelector lookup to be disabled
+#This is added to avoid helm install / helm template break when used with --dry-run for nodeSelector
+# Whenever --dry-run is used along with nodeSelector change this flag to false
+#Unfortunately, there is no way to know if --dry-run flag is set to .Release or any other parameter
+#To be review again when this open helm issue is merged https://github.com/helm/helm/pull/9426
+nodeSelectorLookup: true
 
 # Services for Neo4j
 services:


### PR DESCRIPTION
Added unit test cases to check helm template with and without --dry-run flag  when nodeSelectorLookup is set to false
No integration test cases added as its not required here also we do have an existing integration test case to check nodeSelector functionality
No unit test cases added for helm install with --dry-run flag along with nodeSelectorLookup set to false as its the same as helm template