### PR TITLE
add affinity and tolerations on neo4j-admin

### DIFF
--- a/neo4j-admin/templates/neo4j-cronjob.yaml
+++ b/neo4j-admin/templates/neo4j-cronjob.yaml
@@ -33,6 +33,14 @@ spec:
           restartPolicy: Never
           securityContext: {{ .Values.securityContext | toYaml  | nindent 12 }}
           {{- include "neo4j.nodeSelector" . }}
+          {{- if $.Values.affinity }}
+          affinity:
+            {{- $.Values.affinity | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if gt (len $.Values.tolerations) 0 }}
+          tolerations:
+            {{- $.Values.tolerations | toYaml | nindent 12 }}
+          {{- end }}
           containers:
             - name: graph-backup
               image: {{ .Values.neo4j.image }}:{{ .Values.neo4j.imageTag }}

--- a/neo4j-admin/values.yaml
+++ b/neo4j-admin/values.yaml
@@ -141,3 +141,25 @@ resources:
 nodeSelector: {}
 #  label1: "true"
 #  label2: "value1"
+
+# affinity
+affinity: {}
+#  nodeAffinity:
+#    requiredDuringSchedulingIgnoredDuringExecution:
+#      nodeSelectorTerms:
+#        - matchExpressions:
+#            - key: key
+#              operator: In
+#              values:
+#                - value
+
+# tolerations
+tolerations: []
+#- key: key1
+#  operator: Equal
+#  value: value1
+#  effect: NoExecute
+#- key: key2
+#  operator: Equal
+#  value: value2
+#  effect: NoSchedule


### PR DESCRIPTION
nodeSelector is not enough if you want to dedicate a specific Kubernetes node for backups, we also need affinity and tolerations.

Please also cherry pick on 4.4 branch as well, as it seems that the CronJob is not exactly the same on both branches