### PR TITLE
Update deprecated setting in neo4j-config.yaml

### DIFF
--- a/neo4j/templates/neo4j-config.yaml
+++ b/neo4j/templates/neo4j-config.yaml
@@ -108,7 +108,7 @@ data:
 
   {{- if $clusterEnabled }}
   # Clustering
-  dbms.cluster.discovery.type: K8S
+  dbms.cluster.discovery.resolver_type: K8S
   dbms.kubernetes.service_port_name: "tcp-discovery"
   dbms.kubernetes.label_selector: "app={{ template "neo4j.name" . }},helm.neo4j.com/service=internals,helm.neo4j.com/clustering=true"
   dbms.routing.default_router: "SERVER"


### PR DESCRIPTION
Replaced with `dbms.cluster.discovery.resolver_type`.

Config [reference](https://neo4j.com/docs/operations-manual/current/configuration/configuration-settings/#config_dbms.cluster.discovery.resolver_type).
