### PR TITLE
✨ Support node ports for "load balancer" service

### DIFF
--- a/neo4j-loadbalancer/templates/neo4j-svc.yaml
+++ b/neo4j-loadbalancer/templates/neo4j-svc.yaml
@@ -24,24 +24,36 @@ spec:
     - protocol: TCP
       port: {{ .http.port | default 7474 }}
       targetPort: {{ .http.targetPort | default 7474 }}
+      {{- if and (eq $spec.type "NodePort") (.http.nodePort) }}
+      nodePort: {{ .http.nodePort }}
+      {{- end }}
       name: {{ .http.name | default "http" }}
     {{- end }}
     {{- if .https.enabled }}
     - protocol: TCP
       port: {{ .https.port | default 7473 }}
       targetPort: {{ .https.targetPort | default 7473 }}
+      {{- if and (eq $spec.type "NodePort") (.https.nodePort) }}
+      nodePort: {{ .https.nodePort }}
+      {{- end }}
       name: {{ .https.name | default "https" }}
     {{- end }}
     {{- if .bolt.enabled }}
     - protocol: TCP
       port: {{ .bolt.port | default 7687 }}
       targetPort: {{ .bolt.targetPort | default 7687 }}
+      {{- if and (eq $spec.type "NodePort") (.bolt.nodePort) }}
+      nodePort: {{ .bolt.nodePort }}
+      {{- end }}
       name: {{ .bolt.name | default "tcp-bolt" }}
     {{- end }}
     {{- if .backup.enabled }}
     - protocol: TCP
       port: {{ .backup.port | default 6362 }}
       targetPort: {{ .backup.targetPort | default 6362 }}
+      {{- if and (eq $spec.type "NodePort") (.backup.nodePort) }}
+      nodePort: {{ .backup.nodePort }}
+      {{- end }}
       name: {{ .backup.name | default "tcp-backup" }}
     {{- end }}
     {{- end }}

--- a/neo4j-loadbalancer/values.yaml
+++ b/neo4j-loadbalancer/values.yaml
@@ -15,24 +15,36 @@ ports:
     # port: 80
     # targetPort: 7474
     # name: "http"
+    #
+    # if type is NodePort, uncomment to explicitly specify the nodePort to publish http
+    # nodePort: 30474
   https:
     enabled: true #Set this to false to remove HTTPS from this service (this does not affect whether https is enabled for the neo4j process)
-    # uncomment to publish http on port 443 (neo4j default is 7474)
+    # uncomment to publish https on port 443 (neo4j default is 7473)
     # port: 443
     # targetPort: 7473
     # name: "https"
+    #
+    # if type is NodePort, uncomment to explicitly specify the nodePort to publish https
+    # nodePort: 30473
   bolt:
     enabled: true #Set this to false to remove BOLT from this service (this does not affect whether https is enabled for the neo4j process)
     # Uncomment to explicitly specify the port to publish Neo4j Bolt (7687 is the default)
     # port: 7687
     # targetPort: 7687
     # name: "tcp-bolt"
+    #
+    # if type is NodePort, uncomment to explicitly specify the nodePort to publish Neo4j Bolt
+    # nodePort: 30687
   backup:
     enabled: false #Set this to true to expose backup port externally (n.b. this could have security implications. Backup is not authenticated by default)
     # Uncomment to explicitly specify the port to publish Neo4j Backup (6362 is the default)
     # port: 6362
     # targetPort: 6362
     # name: "tcp-backup"
+    #
+    # if type is NodePort, uncomment to explicitly specify the nodePort to publish Neo4j Backup
+    # nodePort: 30362
 
 # A "helm.neo4j.com/neo4j.name" will be applied automatically from `neo4j.name`.
 # Specify *additional* selectors to apply here (generally not required).

--- a/neo4j/templates/neo4j-loadbalancer.yaml
+++ b/neo4j/templates/neo4j-loadbalancer.yaml
@@ -55,18 +55,27 @@ spec:
     - protocol: TCP
       port: {{ .http.port | default 7474 }}
       targetPort: {{ .http.targetPort | default 7474 }}
+      {{- if and (eq $spec.type "NodePort") (.http.nodePort) }}
+      nodePort: {{ .http.nodePort }}
+      {{- end }}
       name: {{ .http.name | default "http" }}
     {{- end }}
     {{- if .https.enabled }}
     - protocol: TCP
       port: {{ .https.port | default 7473 }}
       targetPort: {{ .https.targetPort | default 7473 }}
+      {{- if and (eq $spec.type "NodePort") (.https.nodePort) }}
+      nodePort: {{ .https.nodePort }}
+      {{- end }}
       name: {{ .https.name | default "https" }}
     {{- end }}
     {{- if .bolt.enabled }}
     - protocol: TCP
       port: {{ .bolt.port | default 7687 }}
       targetPort: {{ .bolt.targetPort | default 7687 }}
+      {{- if and (eq $spec.type "NodePort") (.bolt.nodePort) }}
+      nodePort: {{ .bolt.nodePort }}
+      {{- end }}
       name: {{ .bolt.name | default "tcp-bolt" }}
     {{- end }}
     {{ with .backup }}
@@ -74,6 +83,9 @@ spec:
     - protocol: TCP
       port: {{ .port | default 6362 }}
       targetPort: {{ .targetPort | default 6362 }}
+      {{- if and (eq $spec.type "NodePort") (.nodePort) }}
+      nodePort: {{ .nodePort }}
+      {{- end }}
       name: {{ .name | default "tcp-backup" }}
     {{- end }}
     {{- end }}

--- a/neo4j/values.yaml
+++ b/neo4j/values.yaml
@@ -218,24 +218,36 @@ services:
         # port: 80
         # targetPort: 7474
         # name: http
+        #
+        # if type is NodePort, uncomment to explicitly specify the nodePort to publish http
+        # nodePort: 30474
       https:
         enabled: true # Set this to false to remove HTTPS from this service (this does not affect whether https is enabled for the neo4j process)
-        # uncomment to publish http on port 443 (neo4j default is 7473)
+        # uncomment to publish https on port 443 (neo4j default is 7473)
         # port: 443
         # targetPort: 7473
         # name: https
+        #
+        # if type is NodePort, uncomment to explicitly specify the nodePort to publish https
+        # nodePort: 30473
       bolt:
         enabled: true # Set this to false to remove BOLT from this service (this does not affect whether https is enabled for the neo4j process)
         # Uncomment to explicitly specify the port to publish Neo4j Bolt (7687 is the default)
         # port: 7687
         # targetPort: 7687
         # name: tcp-bolt
+        #
+        # if type is NodePort, uncomment to explicitly specify the nodePort to publish Neo4j Bolt
+        # nodePort: 30687
       backup:
         enabled: false # Set this to true to expose backup port externally (n.b. this could have security implications. Backup is not authenticated by default)
         # Uncomment to explicitly specify the port to publish Neo4j Backup (6362 is the default)
         # port: 6362
         # targetPort: 6362
         # name: tcp-backup
+        #
+        # if type is NodePort, uncomment to explicitly specify the nodePort to publish Neo4j Backup
+        # nodePort: 30362
 
     selector:
       "helm.neo4j.com/neo4j.loadbalancer": "include"


### PR DESCRIPTION
Allow to specify the node ports when the "load balancer" service type is NodePort. This is useful when one wants to pin the ports that are exposed by the NodePort service.

See issue #271