### PR TITLE
Continue transferring S3 files after a "large" backup file

### DIFF
--- a/neo4j-admin/backup/aws/operations.go
+++ b/neo4j-admin/backup/aws/operations.go
@@ -74,9 +74,13 @@ func (a *awsClient) UploadFile(fileNames []string, bucketName string) error {
 		if err != nil {
 			return err
 		}
-		//use UploadLargeObject if file size is more than 4GB
+		//use UploadLargeObject if file size is more than 1GB
 		if yes {
-			return a.UploadLargeObject(fileName, location, bucketName, parentBucketName)
+			err := a.UploadLargeObject(fileName, location, bucketName, parentBucketName)
+			if err != nil {
+				return err
+			}
+			continue
 		}
 
 		file, err := os.Open(filePath)

--- a/neo4j-admin/backup/common/operations.go
+++ b/neo4j-admin/backup/common/operations.go
@@ -5,7 +5,7 @@ import (
 	"os"
 )
 
-// IsFileBigger returns true if file size is bigger than 4GB
+// IsFileBigger returns true if file size is bigger than 1GB
 func IsFileBigger(filePath string) (bool, error) {
 	fileInfo, err := os.Stat(filePath)
 	if err != nil {


### PR DESCRIPTION
When backing up data to AWS or Minio S3, the `backup` tool exits cleanly after transferring the first "large" database backup file, but fails to upload any subsequent files to the S3 endpoint.

Below is the output of a run that exits cleanly, but fails to backup all databases.

<details>

<summary>Log output</summary>

```
2024/01/16 18:34:01 printing current directory /var/lib/neo4j
2024/01/16 18:34:01 Address := neo4j-admin.neo4j.svc.cluster.local:6362
2024/01/16 18:34:01 Connectivity established with Database neo4j-admin.neo4j.svc.cluster.local:6362!!
2024/01/16 18:34:01 Connectivity with S3 Bucket 'neo4j-backups' established
2024/01/16 18:34:01 Address := neo4j-admin.neo4j.svc.cluster.local:6362
2024/01/16 18:34:01 Printing backup flags [database backup --from=neo4j-admin.neo4j.svc.cluster.local:6362 --include-metadata=all --keep-failed=false --parallel-recovery=false --type=AUTO --to-path=/backups --verbose database1]
2024/01/16 18:34:12 Backup Completed for database database1 !!
2024/01/16 18:34:12 Backup File Name is database1-2024-01-16T18-34-12.backup
2024/01/16 18:34:12 Printing backup flags [database backup --from=neo4j-admin.neo4j.svc.cluster.local:6362 --include-metadata=all --keep-failed=false --parallel-recovery=false --type=AUTO --to-path=/backups --verbose database2]
2024/01/16 18:34:19 Backup Completed for database database2 !!
2024/01/16 18:34:19 Backup File Name is database2-2024-01-16T18-34-19.backup
2024/01/16 18:34:19 Printing backup flags [database backup --from=neo4j-admin.neo4j.svc.cluster.local:6362 --include-metadata=all --keep-failed=false --parallel-recovery=false --type=AUTO --to-path=/backups --verbose database3]
2024/01/16 18:34:25 Backup Completed for database database3 !!
2024/01/16 18:34:25 Backup File Name is database3-2024-01-16T18-34-25.backup
2024/01/16 18:34:25 Printing backup flags [database backup --from=neo4j-admin.neo4j.svc.cluster.local:6362 --include-metadata=all --keep-failed=false --parallel-recovery=false --type=AUTO --to-path=/backups --verbose database4]
2024/01/16 18:34:31 Backup Completed for database database4 !!
2024/01/16 18:34:31 Backup File Name is database4-2024-01-16T18-34-30.backup
2024/01/16 18:34:31 Printing backup flags [database backup --from=neo4j-admin.neo4j.svc.cluster.local:6362 --include-metadata=all --keep-failed=false --parallel-recovery=false --type=AUTO --to-path=/backups --verbose database5]
2024/01/16 18:34:36 Backup Completed for database database5 !!
2024/01/16 18:34:36 Backup File Name is database5-2024-01-16T18-34-36.backup
2024/01/16 18:34:36 Printing backup flags [database backup --from=neo4j-admin.neo4j.svc.cluster.local:6362 --include-metadata=all --keep-failed=false --parallel-recovery=false --type=AUTO --to-path=/backups --verbose database6]
2024/01/16 18:35:12 Backup Completed for database database6 !!
2024/01/16 18:35:12 Backup File Name is database6-2024-01-16T18-35-09.backup
2024/01/16 18:35:12 Printing backup flags [database backup --from=neo4j-admin.neo4j.svc.cluster.local:6362 --include-metadata=all --keep-failed=false --parallel-recovery=false --type=AUTO --to-path=/backups --verbose database7]
2024/01/16 18:35:17 Backup Completed for database database7 !!
2024/01/16 18:35:17 Backup File Name is database7-2024-01-16T18-35-17.backup
2024/01/16 18:35:17 Printing backup flags [database backup --from=neo4j-admin.neo4j.svc.cluster.local:6362 --include-metadata=all --keep-failed=false --parallel-recovery=false --type=AUTO --to-path=/backups --verbose database8]
2024/01/16 18:35:26 Backup Completed for database database8 !!
2024/01/16 18:35:26 Backup File Name is database8-2024-01-16T18-35-25.backup
2024/01/16 18:35:26 Printing backup flags [database backup --from=neo4j-admin.neo4j.svc.cluster.local:6362 --include-metadata=all --keep-failed=false --parallel-recovery=false --type=AUTO --to-path=/backups --verbose database9]
2024/01/16 18:35:32 Backup Completed for database database9 !!
2024/01/16 18:35:32 Backup File Name is database9-2024-01-16T18-35-32.backup
2024/01/16 18:35:32 Printing backup flags [database backup --from=neo4j-admin.neo4j.svc.cluster.local:6362 --include-metadata=all --keep-failed=false --parallel-recovery=false --type=AUTO --to-path=/backups --verbose database10]
2024/01/16 18:35:39 Backup Completed for database database10 !!
2024/01/16 18:35:39 Backup File Name is database10-2024-01-16T18-35-39.backup
2024/01/16 18:35:39 Printing backup flags [database backup --from=neo4j-admin.neo4j.svc.cluster.local:6362 --include-metadata=all --keep-failed=false --parallel-recovery=false --type=AUTO --to-path=/backups --verbose database11]
2024/01/16 18:35:45 Backup Completed for database database11 !!
2024/01/16 18:35:45 Backup File Name is database11-2024-01-16T18-35-45.backup
2024/01/16 18:35:45 Printing backup flags [database backup --from=neo4j-admin.neo4j.svc.cluster.local:6362 --include-metadata=all --keep-failed=false --parallel-recovery=false --type=AUTO --to-path=/backups --verbose database12]
2024/01/16 18:35:51 Backup Completed for database database12 !!
2024/01/16 18:35:51 Backup File Name is database12-2024-01-16T18-35-50.backup
2024/01/16 18:35:51 Printing backup flags [database backup --from=neo4j-admin.neo4j.svc.cluster.local:6362 --include-metadata=all --keep-failed=false --parallel-recovery=false --type=AUTO --to-path=/backups --verbose database13]
2024/01/16 18:35:56 Backup Completed for database database13 !!
2024/01/16 18:35:56 Backup File Name is database13-2024-01-16T18-35-56.backup
2024/01/16 18:35:56 Printing backup flags [database backup --from=neo4j-admin.neo4j.svc.cluster.local:6362 --include-metadata=all --keep-failed=false --parallel-recovery=false --type=AUTO --to-path=/backups --verbose database14]
2024/01/16 18:36:02 Backup Completed for database database14 !!
2024/01/16 18:36:02 Backup File Name is database14-2024-01-16T18-36-01.backup
2024/01/16 18:36:02 Printing backup flags [database backup --from=neo4j-admin.neo4j.svc.cluster.local:6362 --include-metadata=all --keep-failed=false --parallel-recovery=false --type=AUTO --to-path=/backups --verbose database15]
2024/01/16 18:36:09 Backup Completed for database database15 !!
2024/01/16 18:36:09 Backup File Name is database15-2024-01-16T18-36-08.backup
2024/01/16 18:36:09 Printing backup flags [database backup --from=neo4j-admin.neo4j.svc.cluster.local:6362 --include-metadata=all --keep-failed=false --parallel-recovery=false --type=AUTO --to-path=/backups --verbose database15test]
2024/01/16 18:36:14 Backup Completed for database database15test !!
2024/01/16 18:36:14 Backup File Name is database15test-2024-01-16T18-36-13.backup
2024/01/16 18:36:14 Printing backup flags [database backup --from=neo4j-admin.neo4j.svc.cluster.local:6362 --include-metadata=all --keep-failed=false --parallel-recovery=false --type=AUTO --to-path=/backups --verbose database16]
2024/01/16 18:36:28 Backup Completed for database database16 !!
2024/01/16 18:36:28 Backup File Name is database16-2024-01-16T18-36-27.backup
2024/01/16 18:36:28 Printing backup flags [database backup --from=neo4j-admin.neo4j.svc.cluster.local:6362 --include-metadata=all --keep-failed=false --parallel-recovery=false --type=AUTO --to-path=/backups --verbose database17]
2024/01/16 18:36:33 Backup Completed for database database17 !!
2024/01/16 18:36:33 Backup File Name is database17-2024-01-16T18-36-33.backup
2024/01/16 18:36:33 Printing backup flags [database backup --from=neo4j-admin.neo4j.svc.cluster.local:6362 --include-metadata=all --keep-failed=false --parallel-recovery=false --type=AUTO --to-path=/backups --verbose neo4j]
2024/01/16 18:36:39 Backup Completed for database neo4j !!
2024/01/16 18:36:39 Backup File Name is neo4j-2024-01-16T18-36-38.backup
2024/01/16 18:36:39 Printing backup flags [database backup --from=neo4j-admin.neo4j.svc.cluster.local:6362 --include-metadata=all --keep-failed=false --parallel-recovery=false --type=AUTO --to-path=/backups --verbose database18]
2024/01/16 18:36:44 Backup Completed for database database18 !!
2024/01/16 18:36:44 Backup File Name is database18-2024-01-16T18-36-44.backup
2024/01/16 18:36:44 Printing backup flags [database backup --from=neo4j-admin.neo4j.svc.cluster.local:6362 --include-metadata=all --keep-failed=false --parallel-recovery=false --type=AUTO --to-path=/backups --verbose database19]
2024/01/16 18:36:52 Backup Completed for database database19 !!
2024/01/16 18:36:52 Backup File Name is database19-2024-01-16T18-36-52.backup
2024/01/16 18:36:52 Printing backup flags [database backup --from=neo4j-admin.neo4j.svc.cluster.local:6362 --include-metadata=all --keep-failed=false --parallel-recovery=false --type=AUTO --to-path=/backups --verbose database20]
2024/01/16 18:37:15 Backup Completed for database database20 !!
2024/01/16 18:37:15 Backup File Name is database20-2024-01-16T18-37-13.backup
2024/01/16 18:37:15 Printing backup flags [database backup --from=neo4j-admin.neo4j.svc.cluster.local:6362 --include-metadata=all --keep-failed=false --parallel-recovery=false --type=AUTO --to-path=/backups --verbose database21]
2024/01/16 18:37:20 Backup Completed for database database21 !!
2024/01/16 18:37:20 Backup File Name is database21-2024-01-16T18-37-20.backup
2024/01/16 18:37:20 Printing backup flags [database backup --from=neo4j-admin.neo4j.svc.cluster.local:6362 --include-metadata=all --keep-failed=false --parallel-recovery=false --type=AUTO --to-path=/backups --verbose system]
2024/01/16 18:37:26 Backup Completed for database system !!
2024/01/16 18:37:26 Backup File Name is system-2024-01-16T18-37-25.backup
2024/01/16 18:37:26 Starting upload of file /backups/database1-2024-01-16T18-34-12.backup
2024/01/16 18:37:26 KeyName := database1-2024-01-16T18-34-12.backup
2024/01/16 18:37:28 File database1-2024-01-16T18-34-12.backup uploaded to s3 bucket neo4j-backups !!
2024/01/16 18:37:28 Starting upload of file /backups/database2-2024-01-16T18-34-19.backup
2024/01/16 18:37:28 KeyName := database2-2024-01-16T18-34-19.backup
2024/01/16 18:37:29 File database2-2024-01-16T18-34-19.backup uploaded to s3 bucket neo4j-backups !!
2024/01/16 18:37:29 Starting upload of file /backups/database3-2024-01-16T18-34-25.backup
2024/01/16 18:37:29 KeyName := database3-2024-01-16T18-34-25.backup
2024/01/16 18:37:30 File database3-2024-01-16T18-34-25.backup uploaded to s3 bucket neo4j-backups !!
2024/01/16 18:37:30 Starting upload of file /backups/database4-2024-01-16T18-34-30.backup
2024/01/16 18:37:30 KeyName := database4-2024-01-16T18-34-30.backup
2024/01/16 18:37:30 File database4-2024-01-16T18-34-30.backup uploaded to s3 bucket neo4j-backups !!
2024/01/16 18:37:30 Starting upload of file /backups/database5-2024-01-16T18-34-36.backup
2024/01/16 18:37:30 KeyName := database5-2024-01-16T18-34-36.backup
2024/01/16 18:37:31 File database5-2024-01-16T18-34-36.backup uploaded to s3 bucket neo4j-backups !!
2024/01/16 18:37:31 Starting upload of file /backups/database6-2024-01-16T18-35-09.backup
2024/01/16 18:37:31 KeyName := database6-2024-01-16T18-35-09.backup
2024/01/16 18:37:43 File (Large) database6-2024-01-16T18-35-09.backup uploaded to s3 bucket neo4j-backups !!
```

<details>

We're using a `DATABASE` environment variable with several explicitly specified databases.