### PR TITLE
feat: serviceaccount creation

### DIFF
--- a/neo4j/templates/_helpers.tpl
+++ b/neo4j/templates/_helpers.tpl
@@ -376,3 +376,11 @@ topologySpreadConstraints:
 {{ toYaml $.Values.podSpec.topologySpreadConstraints }}
     {{- end }}
 {{- end -}}
+
+{{- define "neo4j.serviceAccountName" -}}
+    {{- if and (kindIs "string" .Values.podSpec.serviceAccountName) .Values.podSpec.serviceAccountName -}}
+        {{ .Values.podSpec.serviceAccountName }}
+    {{- else -}}
+        {{ default (include "neo4j.fullname" .) .Values.serviceAccount.name }}
+    {{- end -}}
+{{- end -}}    

--- a/neo4j/templates/neo4j-service-account.yaml
+++ b/neo4j/templates/neo4j-service-account.yaml
@@ -1,13 +1,17 @@
 {{- $clusterEnabled := eq (include "neo4j.isClusterEnabled" .) "true" }}
-{{- if or (and $clusterEnabled (empty $.Values.podSpec.serviceAccountName)) $.Values.analytics.enabled }}
+{{- if or (and $clusterEnabled (empty $.Values.podSpec.serviceAccountName)) $.Values.analytics.enabled $.Values.serviceAccount.create}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   namespace: "{{ .Release.Namespace }}"
-  name: {{ include "neo4j.fullname" . }}
+  name: {{ include "neo4j.serviceAccountName" . }}
   labels:
     app: "{{ template "neo4j.name" $ }}"
     {{- include "neo4j.labels" $.Values.neo4j | indent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -32,7 +36,7 @@ metadata:
     {{- include "neo4j.labels" $.Values.neo4j | indent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "neo4j.fullname" . }}
+    name: {{ include "neo4j.serviceAccountName" . }}
 roleRef:
   # "roleRef" specifies the binding to a Role / ClusterRole
   kind: Role # this must be Role or ClusterRole
@@ -63,7 +67,7 @@ metadata:
     {{- include "neo4j.labels" $.Values.neo4j | indent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "neo4j.fullname" . }}
+    name: {{ include "neo4j.serviceAccountName" . }}
 roleRef:
   # "roleRef" specifies the binding to a Role / ClusterRole
   kind: Role # this must be Role or ClusterRole

--- a/neo4j/templates/neo4j-statefulset.yaml
+++ b/neo4j/templates/neo4j-statefulset.yaml
@@ -54,8 +54,8 @@ spec:
         {{- include "neo4j.annotations" $.Values.podSpec.annotations | indent 8 }}
     spec:
       {{- include "neo4j.affinity" . | indent 6 }}
-      {{- if or $.Values.analytics.enabled $.Values.podSpec.serviceAccountName $clusterEnabled }}
-      serviceAccountName: "{{ if kindIs "string" $.Values.podSpec.serviceAccountName | and $.Values.podSpec.serviceAccountName }}{{ $.Values.podSpec.serviceAccountName }}{{ else }}{{ include "neo4j.fullname" . }}{{ end }}"
+      {{- if or $.Values.analytics.enabled $.Values.podSpec.serviceAccountName $clusterEnabled $.Values.serviceAccount.name }}
+      serviceAccountName: "{{ include "neo4j.serviceAccountName" . }}"
       {{- end }}
       dnsPolicy: {{ .Values.podSpec.dnsPolicy | default "ClusterFirst" }}
       securityContext: {{ toYaml .Values.securityContext | nindent 8 }}

--- a/neo4j/values.yaml
+++ b/neo4j/values.yaml
@@ -668,6 +668,15 @@ podDisruptionBudget:
   minAvailable: ""
   maxUnavailable: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 # Service Monitor for prometheus
 # Please ensure prometheus operator or the service monitor CRD is present in your cluster before using service monitor config
 serviceMonitor:


### PR DESCRIPTION
* adding a possibility to create necessary neo4j service account as part of the helm chart with a given name
* adding a possibility to provide annotations through the helm chart
* refactoring if/else from inside the statefulset template into own helper function
* ensuring this is not breaking in the process (will default to `(include "neo4j.fullname" .)` or `podSpec.serviceAccountName` if provided)