### PR TITLE
Improve namespacing of templates to prevent conflicts between charts

### DIFF
--- a/neo4j-admin/templates/_helpers.tpl
+++ b/neo4j-admin/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "neo4j.fullname" -}}
+{{- define "neo4jAdmin.fullname" -}}
     {{- if .Values.fullnameOverride -}}
         {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
     {{- else -}}
@@ -20,7 +20,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/* checkNodeSelectorLabels checks if there is any node in the cluster which has nodeSelector labels */}}
-{{- define "neo4j.checkNodeSelectorLabels" -}}
+{{- define "neo4jAdmin.checkNodeSelectorLabels" -}}
     {{- if and (not (empty $.Values.nodeSelector)) (not $.Values.disableLookups) -}}
         {{- $validNodes := 0 -}}
         {{- $numberOfLabelsRequired := len $.Values.nodeSelector -}}
@@ -48,7 +48,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
     {{- end -}}
 {{- end -}}
 
-{{- define "neo4j.tolerations" -}}
+{{- define "neo4jAdmin.tolerations" -}}
 {{/* Add tolerations only if .Values.tolerations contains entries */}}
     {{- if . -}}
 tolerations:
@@ -56,14 +56,14 @@ tolerations:
     {{- end -}}
 {{- end -}}
 
-{{- define "neo4j.affinity" -}}
+{{- define "neo4jAdmin.affinity" -}}
     {{- if . -}}
 affinity:
 {{ toYaml . | indent 1 }}
     {{- end -}}
 {{- end -}}
 
-{{- define "neo4j.resourcesAndLimits" -}}
+{{- define "neo4jAdmin.resourcesAndLimits" -}}
 requests:
   ephemeral-storage: {{ .Values.resources.requests.ephemeralStorage | default "4Gi" }}
 

--- a/neo4j-admin/templates/_labels.tpl
+++ b/neo4j-admin/templates/_labels.tpl
@@ -1,4 +1,4 @@
-{{- define "neo4j.labels" -}}
+{{- define "neo4jAdmin.labels" -}}
     {{- with . -}}
         {{- range $name, $value := . }}
 {{ $name }}: "{{ $value }}"
@@ -6,7 +6,7 @@
     {{- end -}}
 {{- end }}
 
-{{- define "neo4j.annotations" -}}
+{{- define "neo4jAdmin.annotations" -}}
     {{- with . -}}
         {{- range $name, $value := . }}
 {{ $name }}: "{{ $value }}"
@@ -14,7 +14,7 @@
     {{- end -}}
 {{- end }}
 
-{{- define "neo4j.nodeSelector" -}}
+{{- define "neo4jAdmin.nodeSelector" -}}
 {{- if and (not (kindIs "invalid" .Values.nodeSelector) ) (not (empty .Values.nodeSelector) ) }}
 {{ printf "nodeSelector" | indent 10 }}: {{ .Values.nodeSelector | toYaml | nindent 12 }}
 {{- end }}

--- a/neo4j-admin/templates/_validation.tpl
+++ b/neo4j-admin/templates/_validation.tpl
@@ -1,8 +1,8 @@
-{{- define "neo4j.backup.checkIfSecretExistsOrNot" -}}
+{{- define "neo4jAdmin.backup.checkIfSecretExistsOrNot" -}}
     {{- if (.Values.backup.secretName | trim) -}}
         {{- if (not .Values.disableLookups) -}}
 
-            {{- include "neo4j.backup.checkIfSecretKeyNameExistsOrNot" . -}}
+            {{- include "neo4jAdmin.backup.checkIfSecretKeyNameExistsOrNot" . -}}
             {{- $secret := (lookup "v1" "Secret" .Release.Namespace .Values.backup.secretName) }}
             {{- $secretExists := $secret | all }}
 
@@ -15,7 +15,7 @@
     {{- end -}}
 {{- end -}}
 
-{{- define "neo4j.backup.checkAzureStorageAccountName" -}}
+{{- define "neo4jAdmin.backup.checkAzureStorageAccountName" -}}
     {{- if eq .Values.backup.cloudProvider "azure" }}
         {{- if and (or (empty .Values.backup.secretName) (empty .Values.backup.secretKeyName)) (empty .Values.backup.azureStorageAccountName) -}}
             {{ fail (printf "Both secretName|secretKeyName and azureStorageAccountName key cannot be empty. Please set one of them via --set backup.secretName or --set backup.azureStorageAccountName") }}
@@ -28,7 +28,7 @@
 {{- end -}}
 
 {{/*check for secretKeyName existence only when secretName is provided*/}}
-{{- define "neo4j.backup.checkIfSecretKeyNameExistsOrNot" -}}
+{{- define "neo4jAdmin.backup.checkIfSecretKeyNameExistsOrNot" -}}
    {{- if .Values.backup.secretName -}}
     {{- if kindIs "invalid" .Values.backup.secretKeyName -}}
         {{- fail (printf "Missing secretKeyName !!") -}}
@@ -40,14 +40,14 @@
 {{- end -}}
 
 {{/* checks if serviceAccountName is provided or not  when secretName is missing */}}
-{{- define "neo4j.backup.checkServiceAccountName" -}}
+{{- define "neo4jAdmin.backup.checkServiceAccountName" -}}
     {{- if and (empty .Values.serviceAccountName) (empty .Values.backup.secretName) (not (empty .Values.backup.cloudProvider)) -}}
         {{ fail (printf "Please provide either secretName or serviceAccountName. Both cannot be empty. Please set only one of them via --set backup.secretName or --set serviceAccountName") }}
     {{- end -}}
 {{- end -}}
 
 {{/* checks if serviceAccountName is provided or not  when secretName is missing */}}
-{{- define "neo4j.backup.checkBucketName" -}}
+{{- define "neo4jAdmin.backup.checkBucketName" -}}
     {{- if or (kindIs "invalid" .Values.backup.aggregate) (not .Values.backup.aggregate.enabled) -}}
         {{- if .Values.backup.cloudProvider -}}
             {{- if empty .Values.backup.bucketName -}}
@@ -57,7 +57,7 @@
     {{- end -}}
 {{- end -}}
 
-{{- define "neo4j.backup.checkDatabaseIPAndServiceName" -}}
+{{- define "neo4jAdmin.backup.checkDatabaseIPAndServiceName" -}}
 
     {{- if or (kindIs "invalid" .Values.backup.aggregate) (not .Values.backup.aggregate.enabled) -}}
         {{- if and (kindIs "invalid" .Values.backup.databaseAdminServiceName) (kindIs "invalid" .Values.backup.databaseAdminServiceIP) -}}

--- a/neo4j-admin/templates/neo4j-cronjob.yaml
+++ b/neo4j-admin/templates/neo4j-cronjob.yaml
@@ -1,22 +1,22 @@
-{{- template "neo4j.backup.checkDatabaseIPAndServiceName" . -}}
-{{- template "neo4j.backup.checkAzureStorageAccountName" . -}}
-{{- template "neo4j.backup.checkIfSecretExistsOrNot" . -}}
-{{- template "neo4j.backup.checkBucketName" . -}}
-{{- template "neo4j.backup.checkServiceAccountName" . -}}
-{{- template "neo4j.checkNodeSelectorLabels" . -}}
+{{- template "neo4jAdmin.backup.checkDatabaseIPAndServiceName" . -}}
+{{- template "neo4jAdmin.backup.checkAzureStorageAccountName" . -}}
+{{- template "neo4jAdmin.backup.checkIfSecretExistsOrNot" . -}}
+{{- template "neo4jAdmin.backup.checkBucketName" . -}}
+{{- template "neo4jAdmin.backup.checkServiceAccountName" . -}}
+{{- template "neo4jAdmin.checkNodeSelectorLabels" . -}}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: "{{ include "neo4j.fullname" . }}"
+  name: "{{ include "neo4jAdmin.fullname" . }}"
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/instance: {{ include "neo4j.fullname" . | quote }}
+    app.kubernetes.io/instance: {{ include "neo4jAdmin.fullname" . | quote }}
     {{- if and (not (kindIs "invalid" .Values.backup.aggregate)) .Values.backup.aggregate.enabled }}
     app.kubernetes.io/component: aggregate-backup
     {{- else }}
     app.kubernetes.io/component: backup
     {{- end }}
-    {{- include "neo4j.labels" $.Values.neo4j.labels | indent 4 }}
+    {{- include "neo4jAdmin.labels" $.Values.neo4j.labels | indent 4 }}
 spec:
   schedule: {{ $.Values.neo4j.jobSchedule | default "* * * * *" | quote }}
   concurrencyPolicy: Forbid
@@ -28,9 +28,9 @@ spec:
       template:
         metadata:
           annotations:
-            {{- include "neo4j.annotations" $.Values.neo4j.podAnnotations | indent 12 }}
+            {{- include "neo4jAdmin.annotations" $.Values.neo4j.podAnnotations | indent 12 }}
           labels:
-            {{- include "neo4j.labels" $.Values.neo4j.podLabels | indent 12 }}
+            {{- include "neo4jAdmin.labels" $.Values.neo4j.podLabels | indent 12 }}
         spec:
           {{- if .Values.serviceAccountName }}
           serviceAccountName: {{ .Values.serviceAccountName }}
@@ -39,14 +39,14 @@ spec:
           {{- end }}
           restartPolicy: Never
           securityContext: {{ .Values.securityContext | toYaml  | nindent 12 }}
-          {{- include "neo4j.tolerations" .Values.tolerations | nindent 10 }}
-          {{- include "neo4j.affinity" .Values.affinity| nindent 10 }}
-          {{- include "neo4j.nodeSelector" . }}
+          {{- include "neo4jAdmin.tolerations" .Values.tolerations | nindent 10 }}
+          {{- include "neo4jAdmin.affinity" .Values.affinity| nindent 10 }}
+          {{- include "neo4jAdmin.nodeSelector" . }}
           containers:
             - name: graph-backup
               image: {{ .Values.neo4j.image }}:{{ .Values.neo4j.imageTag }}
               imagePullPolicy: Always
-              resources: {{- include "neo4j.resourcesAndLimits" . | nindent 16 }}
+              resources: {{- include "neo4jAdmin.resourcesAndLimits" . | nindent 16 }}
               env:
                 - name: DATABASE_SERVICE_NAME
                   value: {{ .Values.backup.databaseAdminServiceName  | trim }}

--- a/neo4j-docker-desktop-pv/templates/_helpers.tpl
+++ b/neo4j-docker-desktop-pv/templates/_helpers.tpl
@@ -1,3 +1,3 @@
-{{- define "neo4j.appName" -}}
+{{- define "neo4jDockerDesktopPv.appName" -}}
   {{ required "neo4j.name is required" .Values.neo4j.name }}
 {{- end -}}

--- a/neo4j-docker-desktop-pv/templates/persistentvolume.yaml
+++ b/neo4j-docker-desktop-pv/templates/persistentvolume.yaml
@@ -4,7 +4,7 @@ metadata:
   # n.b. persistent volumes don't seem to belong to namespaces
   name: "{{ .Release.Name }}"
   labels:
-    app: "{{ template "neo4j.appName" . }}"
+    app: "{{ template "neo4jDockerDesktopPv.appName" . }}"
     helm.neo4j.com/volume-role: "data"
 spec:
   accessModes:
@@ -21,7 +21,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: "{{ .Release.Name }}"
   labels:
-    app: "{{ template "neo4j.appName" . }}"
+    app: "{{ template "neo4jDockerDesktopPv.appName" . }}"
     helm.neo4j.com/volume-role: "data"
 spec:
   storageClassName: ""

--- a/neo4j-headless-service/templates/NOTES.txt
+++ b/neo4j-headless-service/templates/NOTES.txt
@@ -1,8 +1,8 @@
-{{- define "neo4j.namespaceParameter" -}}
+{{- define "neo4jHeadlessService.namespaceParameter" -}}
 {{ if ne "default" .Release.Namespace }} --namespace "{{.Release.Namespace}}"{{ end }}
 {{- end -}}
 
-{{- define "neo4j.logPassword" -}}
+{{- define "neo4jHeadlessService.logPassword" -}}
 {{ if .Values.logInitialPassword }}{{ .Values.neo4j.password }}{{ else }}**********{{ end }}
 {{- end -}}
 
@@ -24,7 +24,7 @@ You have updated {{ .Chart.Name }} in namespace "{{ .Release.Namespace }}".
 
 Once rollout is complete you can connect to your Neo4j cluster using "neo4j://{{ .Release.Name }}-neo4j.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ $boltPort }}". Try:
 
-  $ kubectl run --rm -it{{ template "neo4j.namespaceParameter" . }} --image "{{ template "neo4j.image" . }}" cypher-shell \
-     -- cypher-shell -a "neo4j://{{ template "neo4j.name" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ $boltPort }}"{{ if not $authDisabled | and .Values.neo4j.password |and .Values.logInitialPassword}} -u neo4j -p "{{ template "neo4j.logPassword" . }}"{{ end }}
+  $ kubectl run --rm -it{{ template "neo4jHeadlessService.image" . }}" cypher-shell \
+     -- cypher-shell -a "neo4j://{{ template "neo4jHeadlessService.logPassword" . }}"{{ end }}
 
 Graphs are everywhere!

--- a/neo4j-headless-service/templates/_helpers.tpl
+++ b/neo4j-headless-service/templates/_helpers.tpl
@@ -1,4 +1,4 @@
-{{- define "neo4j.name" -}}
+{{- define "neo4jHeadlessService.name" -}}
   {{- if eq (len (trim $.Values.neo4j.name)) 0 -}}
     {{- fail (printf "neo4j.name is required") -}}
   {{- else -}}
@@ -6,27 +6,27 @@
   {{- end -}}
 {{- end -}}
 
-{{- define "neo4j.checkPortMapping" -}}
+{{- define "neo4jHeadlessService.checkPortMapping" -}}
     {{- $httpPort := .Values.ports.http.port | int | default 7474 -}}
     {{- $httpsPort := .Values.ports.https.port | int | default 7473 -}}
     {{- $boltPort := .Values.ports.bolt.port | int | default 7687 -}}
     {{- $backupPort := .Values.ports.backup.port | int | default 6362 -}}
 
     {{- if and (eq .Values.ports.http.enabled true) (ne $httpPort 7474) -}}
-        {{- include "neo4j.portRemappingFailureMessage" $httpPort -}}
+        {{- include "neo4jHeadlessService.portRemappingFailureMessage" $httpPort -}}
     {{- end -}}
     {{- if and (eq .Values.ports.https.enabled true) (ne $httpsPort 7473) -}}
-        {{- include "neo4j.portRemappingFailureMessage" $httpsPort -}}
+        {{- include "neo4jHeadlessService.portRemappingFailureMessage" $httpsPort -}}
     {{- end -}}
     {{- if and (eq .Values.ports.bolt.enabled true) (ne $boltPort 7687) -}}
-        {{- include "neo4j.portRemappingFailureMessage" $boltPort -}}
+        {{- include "neo4jHeadlessService.portRemappingFailureMessage" $boltPort -}}
     {{- end -}}
     {{- if and (eq .Values.ports.backup.enabled true) (ne $backupPort 6362) -}}
-        {{- include "neo4j.portRemappingFailureMessage" $backupPort -}}
+        {{- include "neo4jHeadlessService.portRemappingFailureMessage" $backupPort -}}
     {{- end -}}
 {{- end -}}
 
-{{- define "neo4j.portRemappingFailureMessage" -}}
+{{- define "neo4jHeadlessService.portRemappingFailureMessage" -}}
     {{- $message := . | printf "port re-mapping is not allowed in headless service. Please remove custom port %d from values.yaml" -}}
     {{- fail $message -}}
 {{- end -}}

--- a/neo4j-headless-service/templates/_image.tpl
+++ b/neo4j-headless-service/templates/_image.tpl
@@ -1,4 +1,4 @@
-{{- define "neo4j.defaultChartImage" -}}
+{{- define "neo4jHeadlessService.defaultChartImage" -}}
 {{- $isEnterprise := required "neo4j.edition must be specified" .Values.neo4j.edition | regexMatch "(?i)enterprise" -}}
  {{- $imageName := "neo4j:" -}}
  {{/* .Chart.AppVersion is set to "-" for headless and loadbalancer service*/}}
@@ -14,9 +14,9 @@
 {{- end -}}
 
 
-{{- define "neo4j.image" -}}
-{{- template "neo4j.checkLicenseAgreement" . -}}
-{{- $image := include "neo4j.defaultChartImage" . -}}
+{{- define "neo4jHeadlessService.image" -}}
+{{- template "neo4jHeadlessService.checkLicenseAgreement" . -}}
+{{- $image := include "neo4jHeadlessService.defaultChartImage" . -}}
 {{/* Allow override if a custom image has been specified */}}
 {{- if .Values.image -}}
   {{- if .Values.image.customImage -}}

--- a/neo4j-headless-service/templates/_licensing.tpl
+++ b/neo4j-headless-service/templates/_licensing.tpl
@@ -1,17 +1,17 @@
-{{- define "neo4j.checkLicenseAgreement" }}
+{{- define "neo4jHeadlessService.checkLicenseAgreement" }}
 {{- $isEnterprise := required "neo4j.edition must be specified" .Values.neo4j.edition | regexMatch "(?i)enterprise" -}}
 {{- if $isEnterprise }}
   {{- if not (kindIs "string" .Values.neo4j.acceptLicenseAgreement) | or (not .Values.neo4j.acceptLicenseAgreement) }}
-  {{- include "neo4j.licenseAgreementMessage" .Values.neo4j.acceptLicenseAgreement | fail }}
+  {{- include "neo4jHeadlessService.licenseAgreementMessage" .Values.neo4j.acceptLicenseAgreement | fail }}
   {{- else }}
   {{- if ne .Values.neo4j.acceptLicenseAgreement "yes" }}
-    {{- include "neo4j.licenseAgreementMessage" .Values.neo4j.acceptLicenseAgreement | fail }}
+    {{- include "neo4jHeadlessService.licenseAgreementMessage" .Values.neo4j.acceptLicenseAgreement | fail }}
   {{- end }}
   {{- end }}
 {{- end }}
 {{- end }}
 
-{{- define "neo4j.licenseAgreementMessage" }}
+{{- define "neo4jHeadlessService.licenseAgreementMessage" }}
 
 In order to use Neo4j Enterprise Edition you must have a Neo4j license agreement.
 More information is available at: https://neo4j.com/licensing/

--- a/neo4j-headless-service/templates/neo4j-svc.yaml
+++ b/neo4j-headless-service/templates/neo4j-svc.yaml
@@ -1,13 +1,13 @@
 {{- /* In almost all cases the selector should be unspecified and the default selector should be used. */ -}}
-{{- template "neo4j.checkPortMapping" . -}}
+{{- template "neo4jHeadlessService.checkPortMapping" . -}}
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ include "neo4j.name" $ }}-headless"
+  name: "{{ include "neo4jHeadlessService.name" $ }}-headless"
   namespace: "{{ .Release.Namespace }}"
   labels:
-    helm.neo4j.com/neo4j.name: "{{ template "neo4j.name" $ }}"
-    app: "{{ template "neo4j.name" . }}"
+    helm.neo4j.com/neo4j.name: "{{ template "neo4jHeadlessService.name" $ }}"
+    app: "{{ template "neo4jHeadlessService.name" . }}"
   {{- with .Values.annotations }}
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}
@@ -46,7 +46,7 @@ spec:
     {{- end }}
 
   selector:
-    app: "{{ template "neo4j.name" . }}"
+    app: "{{ template "neo4jHeadlessService.name" . }}"
     {{- with .Values.selector }}
     {{- . | toYaml | nindent 4 }}
     {{- end }}

--- a/neo4j-loadbalancer/templates/_helpers.tpl
+++ b/neo4j-loadbalancer/templates/_helpers.tpl
@@ -1,7 +1,7 @@
-{{- define "neo4j.name" -}}
+{{- define "neo4jLoadbalancer.name" -}}
   {{- required "neo4j.name is required" .Values.neo4j.name }}
 {{- end -}}
 
-{{- define "neo4j.appName" -}}
+{{- define "neo4jLoadbalancer.appName" -}}
   {{- required "neo4j.name is required" .Values.neo4j.name }}
 {{- end -}}

--- a/neo4j-loadbalancer/templates/_labels.tpl
+++ b/neo4j-loadbalancer/templates/_labels.tpl
@@ -1,4 +1,4 @@
-{{- define "neo4j.labels" -}}
+{{- define "neo4jLoadbalancer.labels" -}}
     {{- with .labels -}}
         {{- range $name, $value := . }}
 {{ $name | quote}}: {{ $value | quote }}
@@ -6,7 +6,7 @@
     {{- end -}}
 {{- end }}
 
-{{- define "neo4j.annotations" -}}
+{{- define "neo4jLoadbalancer.annotations" -}}
     {{- with . -}}
         {{- range $name, $value := . }}
 {{ $name | quote }}: {{ $value | quote }}

--- a/neo4j-loadbalancer/templates/_loadbalancer.tpl
+++ b/neo4j-loadbalancer/templates/_loadbalancer.tpl
@@ -1,4 +1,4 @@
-{{- define "neo4j.services.neo4j.defaultSpec" -}}
+{{- define "neo4jLoadbalancer.services.neo4j.defaultSpec" -}}
 ClusterIP:
   sessionAffinity: None
 NodePort:
@@ -10,7 +10,7 @@ LoadBalancer:
 {{- end }}
 
 
-{{- define "neo4j.services.extraSpec" -}}
+{{- define "neo4jLoadbalancer.services.extraSpec" -}}
 {{- if hasKey . "type" }}{{ fail "field 'type' is not supported in Neo4j LoadBalancer Helm Chart service.*.spec" }}{{ end }}
 {{- if hasKey . "selector" }}{{ fail "field 'selector' is not supported in Neo4j LoadBalancer Helm Chart service.*.spec" }}{{ end }}
 {{- if hasKey . "ports" }}{{ fail "field 'ports' is not supported in Neo4j Helm LoadBalancerChart service .*.spec" }}{{ end }}

--- a/neo4j-loadbalancer/templates/neo4j-svc.yaml
+++ b/neo4j-loadbalancer/templates/neo4j-svc.yaml
@@ -1,23 +1,23 @@
-{{- $defaultSpec := include "neo4j.services.neo4j.defaultSpec" . | fromYaml }}
+{{- $defaultSpec := include "neo4jLoadbalancer.services.neo4j.defaultSpec" . | fromYaml }}
 {{- $spec := get $defaultSpec .Values.spec.type | merge .Values.spec  }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ include "neo4j.name" $ }}-lb-neo4j"
+  name: "{{ include "neo4jLoadbalancer.name" $ }}-lb-neo4j"
   namespace: "{{ .Release.Namespace }}"
   labels:
-    helm.neo4j.com/neo4j.name: "{{ template "neo4j.name" $ }}"
-    app: "{{ template "neo4j.name" . }}"
+    helm.neo4j.com/neo4j.name: "{{ template "neo4jLoadbalancer.name" $ }}"
+    app: "{{ template "neo4jLoadbalancer.name" . }}"
     helm.neo4j.com/service: "neo4j"
-    {{- include "neo4j.labels" .Values.neo4j | indent 4 }}
+    {{- include "neo4jLoadbalancer.labels" .Values.neo4j | indent 4 }}
   annotations:
-  {{- include "neo4j.annotations" $.Values.annotations | indent 4 }}
+  {{- include "neo4jLoadbalancer.annotations" $.Values.annotations | indent 4 }}
 spec:
   {{- if $.Values.multiCluster }}
   publishNotReadyAddresses: true
   {{- end }}
   type: "{{ $.Values.spec.type | required "service type must be specified" }}"
-  {{- omit $spec "type" "ports" "selector" | include "neo4j.services.extraSpec"  | nindent 2 }}
+  {{- omit $spec "type" "ports" "selector" | include "neo4jLoadbalancer.services.extraSpec"  | nindent 2 }}
   ports:
     {{- with .Values.ports }}
     {{- if .http.enabled }}
@@ -77,7 +77,7 @@ spec:
       targetPort: 6000
     {{- end }}
   selector:
-    app: "{{ template "neo4j.name" . }}"
+    app: "{{ template "neo4jLoadbalancer.name" . }}"
     {{- with .Values.selector }}
     {{- . | toYaml | nindent 4 }}
     {{- end }}

--- a/neo4j-persistent-volume/templates/_helpers.tpl
+++ b/neo4j-persistent-volume/templates/_helpers.tpl
@@ -1,3 +1,3 @@
-{{- define "neo4j.appName" -}}
+{{- define "neo4jPersistentVolume.appName" -}}
   {{ required "neo4j.name is required" .Values.neo4j.name }}
 {{- end -}}

--- a/neo4j-persistent-volume/templates/data-pv.yaml
+++ b/neo4j-persistent-volume/templates/data-pv.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "{{ $.Release.Name }}-pv"
   labels:
     # the app name is used to link this persistent volume to the Neo4j StatefulSet
-    app: "{{ template "neo4j.appName" $ }}"
+    app: "{{ template "neo4jPersistentVolume.appName" $ }}"
     helm.neo4j.com/volume-role: "data"
 spec:
   accessModes:
@@ -30,7 +30,7 @@ metadata:
   name: "{{ $.Release.Name }}-pvc"
   labels:
     helm.neo4j.com/volume-role: "data"
-    app: "{{ template "neo4j.appName" $ }}"
+    app: "{{ template "neo4jPersistentVolume.appName" $ }}"
 spec:
   storageClassName: "{{ .storageClassName }}"
   volumeName: "{{ $.Release.Name }}-pv"

--- a/neo4j-persistent-volume/templates/ops-pv.yaml
+++ b/neo4j-persistent-volume/templates/ops-pv.yaml
@@ -7,7 +7,7 @@ metadata:
   name: "{{ $.Release.Name }}-ops"
   labels:
     helm.neo4j.com/volume-role: "ops"
-    app: "{{ template "neo4j.appName" $ }}"
+    app: "{{ template "neo4jPersistentVolume.appName" $ }}"
 spec:
   accessModes:
     - ReadWriteMany
@@ -24,7 +24,7 @@ metadata:
   name: "{{ $.Release.Name }}-ops"
   labels:
     helm.neo4j.com/volume-role: "ops"
-    app: "{{ template "neo4j.appName" $ }}"
+    app: "{{ template "neo4jPersistentVolume.appName" $ }}"
 spec:
   storageClassName: "{{ .storageClassName }}"
   volumeName: "{{ $.Release.Name }}-ops"

--- a/neo4j-reverse-proxy/templates/NOTES.txt
+++ b/neo4j-reverse-proxy/templates/NOTES.txt
@@ -1,14 +1,14 @@
 Thank you for installing neo4j-reverse-proxy helm chart
 
 This chart installs the following resources in "{{ .Release.Namespace }}" namespace:
- * Pod = "{{ include "neo4j.fullname" . }}-reverseproxy"
- * ClusterIP service =  "{{ include "neo4j.fullname" . }}-reverseproxy-service"
+ * Pod = "{{ include "neo4jReverseProxy.fullname" . }}-reverseproxy"
+ * ClusterIP service =  "{{ include "neo4jReverseProxy.fullname" . }}-reverseproxy-service"
 
 {{- if $.Values.reverseProxy.ingress.enabled }}
-{{- $ingressName := printf "%s-reverseproxy-ingress" (include "neo4j.fullname" .) -}}
+{{- $ingressName := printf "%s-reverseproxy-ingress" (include "neo4jReverseProxy.fullname" .) -}}
 {{- $hostname := printf "$(kubectl get ingress/%s -n %s -o jsonpath='{.status.loadBalancer.ingress[0].ip}')"  $ingressName .Release.Namespace -}}
-{{- $port := include "neo4j.reverseProxy.port" . }}
- * Ingress = "{{ include "neo4j.fullname" . }}-reverseproxy-ingress"
+{{- $port := include "neo4jReverseProxy.reverseProxy.port" . }}
+ * Ingress = "{{ include "neo4jReverseProxy.fullname" . }}-reverseproxy-ingress"
 
 You can get the ingress address by executing the below command. (It can take a few seconds for the address to appear)
     {{ printf "kubectl get ingress/%s -n %s -o jsonpath='{.status.loadBalancer.ingress[0].ip}'"  $ingressName .Release.Namespace }}

--- a/neo4j-reverse-proxy/templates/_helpers.tpl
+++ b/neo4j-reverse-proxy/templates/_helpers.tpl
@@ -1,4 +1,4 @@
-{{- define "neo4j.fullname" -}}
+{{- define "neo4jReverseProxy.fullname" -}}
     {{- if .Values.fullnameOverride -}}
         {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
     {{- else -}}
@@ -15,7 +15,7 @@
     {{- end -}}
 {{- end -}}
 
-{{- define "neo4j.annotations" -}}
+{{- define "neo4jReverseProxy.annotations" -}}
     {{- if not (empty .) }}
 annotations:
         {{- with . -}}
@@ -26,13 +26,13 @@ annotations:
     {{- end }}
 {{- end }}
 
-{{- define "neo4j.ingress.tls" -}}
+{{- define "neo4jReverseProxy.ingress.tls" -}}
     {{- if and $.Values.reverseProxy.ingress.tls.enabled $.Values.reverseProxy.ingress.tls.config }}
 tls: {{ toYaml $.Values.reverseProxy.ingress.tls.config | nindent 2 }}
     {{- end }}
 {{- end -}}
 
-{{- define "neo4j.reverseProxy.port" -}}
+{{- define "neo4jReverseProxy.reverseProxy.port" -}}
     {{- if $.Values.reverseProxy.ingress.tls.enabled }}
         {{- printf "%d" 443 -}}
     {{- else -}}
@@ -40,8 +40,8 @@ tls: {{ toYaml $.Values.reverseProxy.ingress.tls.config | nindent 2 }}
     {{- end -}}
 {{- end -}}
 
-{{- define "neo4j.reverseProxy.ingressName" -}}
-{{- $ingressName := printf "%s-reverseproxy-ingress" (include "neo4j.fullname" .) -}}
+{{- define "neo4jReverseProxy.reverseProxy.ingressName" -}}
+{{- $ingressName := printf "%s-reverseproxy-ingress" (include "neo4jReverseProxy.fullname" .) -}}
 {{- printf "$(kubectl get ingress/%s -n %s -o jsonpath='{.status.loadBalancer.ingress[0].ip}')"  $ingressName .Release.Namespace -}}
 {{- end -}}
 

--- a/neo4j-reverse-proxy/templates/_validations.tpl
+++ b/neo4j-reverse-proxy/templates/_validations.tpl
@@ -1,4 +1,4 @@
-{{- define "neo4j.reverseProxy.tlsValidation" -}}
+{{- define "neo4jReverseProxy.reverseProxy.tlsValidation" -}}
     {{- if and $.Values.reverseProxy.ingress.enabled $.Values.reverseProxy.ingress.tls.enabled -}}
         {{- if empty $.Values.reverseProxy.ingress.tls.config -}}
             {{ fail (printf "Empty tls config !!") }}

--- a/neo4j-reverse-proxy/templates/ingress.yaml
+++ b/neo4j-reverse-proxy/templates/ingress.yaml
@@ -1,23 +1,23 @@
-{{- template "neo4j.reverseProxy.tlsValidation" . -}}
+{{- template "neo4jReverseProxy.reverseProxy.tlsValidation" . -}}
 {{- if $.Values.reverseProxy.ingress.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "neo4j.fullname" . }}-reverseproxy-ingress
+  name: {{ include "neo4jReverseProxy.fullname" . }}-reverseproxy-ingress
   namespace: "{{ .Release.Namespace }}"
-  {{- include "neo4j.annotations" $.Values.reverseProxy.ingress.annotations | indent 2 }}
+  {{- include "neo4jReverseProxy.annotations" $.Values.reverseProxy.ingress.annotations | indent 2 }}
 spec:
   ingressClassName: "{{ .Values.reverseProxy.ingress.className | default "nginx" }}"
-  {{- include "neo4j.ingress.tls" . | indent 2 }}
+  {{- include "neo4jReverseProxy.ingress.tls" . | indent 2 }}
   rules:
     - http:
         paths:
           - pathType: Prefix
             backend:
               service:
-                name: {{ include "neo4j.fullname" . }}-reverseproxy-service
+                name: {{ include "neo4jReverseProxy.fullname" . }}-reverseproxy-service
                 port:
-                  number: {{ include "neo4j.reverseProxy.port" . }}
+                  number: {{ include "neo4jReverseProxy.reverseProxy.port" . }}
             path: /
       {{- include ".neo4j.ingress.host" . | indent 6 -}}
 {{- end -}}

--- a/neo4j-reverse-proxy/templates/reverseProxyServer.yaml
+++ b/neo4j-reverse-proxy/templates/reverseProxyServer.yaml
@@ -1,25 +1,25 @@
-{{- $port := include "neo4j.reverseProxy.port" . -}}
+{{- $port := include "neo4jReverseProxy.reverseProxy.port" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "neo4j.fullname" . }}-reverseproxy-dep
+  name: {{ include "neo4jReverseProxy.fullname" . }}-reverseproxy-dep
   labels:
-    name: {{ include "neo4j.fullname" . }}-reverseproxy-dep
+    name: {{ include "neo4jReverseProxy.fullname" . }}-reverseproxy-dep
   namespace: "{{ .Release.Namespace }}"
 spec:
   replicas: 1
   selector:
     matchLabels:
-      name: {{ include "neo4j.fullname" . }}-reverseproxy
+      name: {{ include "neo4jReverseProxy.fullname" . }}-reverseproxy
   template:
     metadata:
-      name: {{ include "neo4j.fullname" . }}-reverseproxy
+      name: {{ include "neo4jReverseProxy.fullname" . }}-reverseproxy
       labels:
-        name: {{ include "neo4j.fullname" . }}-reverseproxy
+        name: {{ include "neo4jReverseProxy.fullname" . }}-reverseproxy
     spec:
       securityContext: {{ toYaml .Values.reverseProxy.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ include "neo4j.fullname" . }}-reverseproxy
+        - name: {{ include "neo4jReverseProxy.fullname" . }}-reverseproxy
           image: {{ $.Values.reverseProxy.image }}
           imagePullPolicy: Always
           securityContext: {{ toYaml .Values.reverseProxy.containerSecurityContext | nindent 12 }}
@@ -38,12 +38,12 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "neo4j.fullname" . }}-reverseproxy-service
+  name: {{ include "neo4jReverseProxy.fullname" . }}-reverseproxy-service
   namespace: "{{ .Release.Namespace }}"
 spec:
   type: ClusterIP
   selector:
-    name: {{ include "neo4j.fullname" . }}-reverseproxy
+    name: {{ include "neo4jReverseProxy.fullname" . }}-reverseproxy
   ports:
     - protocol: TCP
       port: {{ $port }}


### PR DESCRIPTION
Currently, some templates are defined in multiple charts under the same name, but with different implementations.  Sometimes these implementations are completely incompatible, such as the `neo4j.nodeSelector` template being incompatible between the `neo4j` and `neo4j-admin` charts.

This is a problem because it is often desirable to maintain these charts together as subcharts of a common parent chart.  For example, I'm trying to use this `Chart.yaml` alongside an appropriate `values.yaml` to manage a database and its associated backup infrastructure in a single chart as part of a larger application:

```yaml
apiVersion: v3
appVersion: "0.1.0"
description:
name: my-neo4j-app
version: 0.1.0
dependencies:
  - name: neo4j
    repository: https://helm.neo4j.com/neo4j
    version: 5.20.0
  - name: neo4j-admin
    alias: neo4j-backup
    repository: https://helm.neo4j.com/neo4j
    version: 5.20.0
    condition: backup.enabled
```

This currently errors out due to the conflicting definitions of some templates.

The solution used here is to namespace all of the templates by the specific chart that they are a part of rather than by simply `neo4j`.  For example, the fullname template in `neo4j-admin` is renamed from `neo4j.fullname` to `neo4jAdmin.fullname` to prevent a potential conflict with the main `neo4j` chart.  The actual method of doing this was just a find-replace of `(?<=define |template )"neo4j.([^"]*)"` for `"<chartname>.$1"` within each chart.

A note on testing: I only tested this so far as making sure it worked for my `neo4j` + `neo4j-admin` setup.  I couldn't figure out how to run the tests locally, but I'm assuming they should run on this PR and catch any cases I might have missed.