### PR TITLE
Default dbms.cluster.discovery.version to V1_ONLY

### DIFF
--- a/internal/unit_tests/helm_template_primaries_test.go
+++ b/internal/unit_tests/helm_template_primaries_test.go
@@ -996,6 +996,7 @@ func TestClusterEnabledConfigMap(t *testing.T) {
 	assert.Contains(t, defaultConfig.Data, "dbms.routing.client_side.enforce_for_domains")
 	assert.Contains(t, defaultConfig.Data, "dbms.routing.enabled")
 	assert.Contains(t, defaultConfig.Data, "dbms.cluster.discovery.version")
+	assert.Contains(t, defaultConfig.Data, "dbms.kubernetes.discovery.v2.service_port_name")
 	assert.Contains(t, defaultConfig.Data, "server.bolt.advertised_address")
 	assert.Contains(t, defaultConfig.Data, "server.discovery.advertised_address")
 	assert.Contains(t, defaultConfig.Data, "server.cluster.raft.advertised_address")

--- a/internal/unit_tests/helm_template_primaries_test.go
+++ b/internal/unit_tests/helm_template_primaries_test.go
@@ -995,6 +995,7 @@ func TestClusterEnabledConfigMap(t *testing.T) {
 	assert.Contains(t, defaultConfig.Data, "dbms.routing.default_router")
 	assert.Contains(t, defaultConfig.Data, "dbms.routing.client_side.enforce_for_domains")
 	assert.Contains(t, defaultConfig.Data, "dbms.routing.enabled")
+	assert.Contains(t, defaultConfig.Data, "dbms.cluster.discovery.version")
 	assert.Contains(t, defaultConfig.Data, "server.bolt.advertised_address")
 	assert.Contains(t, defaultConfig.Data, "server.discovery.advertised_address")
 	assert.Contains(t, defaultConfig.Data, "server.cluster.raft.advertised_address")

--- a/neo4j/templates/neo4j-config.yaml
+++ b/neo4j/templates/neo4j-config.yaml
@@ -126,7 +126,8 @@ data:
   dbms.routing.default_router: "SERVER"
   dbms.routing.client_side.enforce_for_domains: "*.{{ .Values.clusterDomain }}"
   dbms.routing.enabled: "true"
-  dbms.cluster.discovery.version: "V1_ONLY"
+  dbms.cluster.discovery.version: "{{ default "V1_ONLY" .Values.discoveryVersion }}"
+  dbms.kubernetes.discovery.v2.service_port_name: "tcp-tx"
   {{- end }}
 
   {{- if $clusterEnabled }}

--- a/neo4j/templates/neo4j-config.yaml
+++ b/neo4j/templates/neo4j-config.yaml
@@ -126,7 +126,7 @@ data:
   dbms.routing.default_router: "SERVER"
   dbms.routing.client_side.enforce_for_domains: "*.{{ .Values.clusterDomain }}"
   dbms.routing.enabled: "true"
-  dbms.cluster.discovery.version: "{{ default "V1_ONLY" .Values.discoveryVersion }}"
+  dbms.cluster.discovery.version: "{{ .Values.discoveryVersion }}"
   dbms.kubernetes.discovery.v2.service_port_name: "tcp-tx"
   {{- end }}
 

--- a/neo4j/templates/neo4j-config.yaml
+++ b/neo4j/templates/neo4j-config.yaml
@@ -126,6 +126,7 @@ data:
   dbms.routing.default_router: "SERVER"
   dbms.routing.client_side.enforce_for_domains: "*.{{ .Values.clusterDomain }}"
   dbms.routing.enabled: "true"
+  dbms.cluster.discovery.version: "V1_ONLY"
   {{- end }}
 
   {{- if $clusterEnabled }}

--- a/neo4j/values.yaml
+++ b/neo4j/values.yaml
@@ -428,6 +428,9 @@ ssl:
 # Kubernetes cluster domain suffix
 clusterDomain: "cluster.local"
 
+# Discovery version, possible values are V1_ONLY, V1_OVER_V2, V2_OVER_V1, V2_ONLY
+discoveryVersion: "V1_ONLY"
+
 # Override image settings in Neo4j pod
 image:
   imagePullPolicy: IfNotPresent


### PR DESCRIPTION
In the next release (v5.25), we will default `dbms.cluster.discovery.version` to V2_ONLY. In order to keep compatibility for people using helm charts, we will default it to V1_ONLY in the helm charts. 

Should users want to upgrade to V2_ONLY, they will have to to upgrade as described in https://neo4j.com/docs/operations-manual/current/clustering/setup/discovery/
