### PR TITLE
feat: add templating for when bolt is disabled

### DIFF
--- a/neo4j/templates/neo4j-statefulset.yaml
+++ b/neo4j/templates/neo4j-statefulset.yaml
@@ -4,6 +4,7 @@
 {{- $offlineMaintenanceEnabled :=  .Values.neo4j.offlineMaintenanceModeEnabled }}
 {{- $neo4jImage := include "neo4j.image" . }}
 {{- $backupEnabled := false }}
+{{- $boltEnabled := index $.Values.config "server.bolt.enabled" | default "true" | regexMatch "(?i)yes|true" }}
 {{- $httpEnabled := index $.Values.config "server.http.enabled" | default "true" | regexMatch "(?i)yes|true" }}
 {{- $httpsEnabled := index $.Values.config "server.https.enabled" | default "false" | regexMatch "(?i)yes|true" }}
 {{- if $isEnterprise }}
@@ -115,8 +116,10 @@ spec:
             - containerPort: 7474
               name: http
             {{- end }}
+            {{- if $boltEnabled }}
             - containerPort: 7687
               name: bolt
+            {{- end }}
             {{- if $httpsEnabled }}
             - containerPort: 7473
               name: https
@@ -155,8 +158,8 @@ spec:
             {{- if $offlineMaintenanceEnabled  }}
             {{- include "neo4j.maintenanceVolumeMounts" .Values.volumes | indent 12 }}
             {{- end }}
-          {{- include "neo4j.readinessProbe" .Values.readinessProbe | nindent 10 }}  
-          
+          {{- include "neo4j.readinessProbe" .Values.readinessProbe | nindent 10 }}
+
           {{- if $offlineMaintenanceEnabled }}
           # liveness and startup probes are disabled in offlineMaintenanceMode
           {{- else }}

--- a/neo4j/templates/neo4j-svc.yaml
+++ b/neo4j/templates/neo4j-svc.yaml
@@ -5,6 +5,7 @@
 {{- $clusterEnabled = eq (include "neo4j.isClusterEnabled" .) "true" }}
 {{- $backupEnabled = index $.Values.config "server.backup.enabled" | default "true" | regexMatch "(?i)yes|true" }}
 {{- end }}
+{{- $boltEnabled := index $.Values.config "server.bolt.enabled" | default "true" | regexMatch "(?i)yes|true" }}
 {{- $httpEnabled := index $.Values.config "server.http.enabled" | default "true" | regexMatch "(?i)yes|true" }}
 {{- $httpsEnabled := index $.Values.config "server.https.enabled" | default "false" | regexMatch "(?i)yes|true" }}
 {{- $jmxEnabled := index $.Values.config "server.metrics.jmx.enabled" | default "" | regexMatch "(?i)yes|true" }}
@@ -34,10 +35,12 @@ spec:
     app: "{{ template "neo4j.name" $ }}"
     helm.neo4j.com/instance: "{{ include "neo4j.fullname" . }}"
   ports:
+    {{- if $boltEnabled }}
     - protocol: TCP
       port: 7687
       targetPort: 7687
       name: tcp-bolt
+    {{- end }}
     {{- if $httpEnabled }}
     - protocol: TCP
       port: 7474


### PR DESCRIPTION
Since neo4j supports disabling bolt at the application level it should be supported at the helm chart level as well.