### PR TITLE
Ensure keepBackupFiles boolean is handled correctly in env vars

### DIFF
--- a/neo4j-admin/templates/neo4j-cronjob.yaml
+++ b/neo4j-admin/templates/neo4j-cronjob.yaml
@@ -68,7 +68,7 @@ spec:
                 - name: BUCKET_NAME
                   value: {{ .Values.backup.bucketName | trim }}
                 - name: KEEP_BACKUP_FILES
-                  value: {{ (hasKey .Values.backup "keepBackupFiles" | ternary .Values.backup.keepBackupFiles true) | toString}}
+                  value: {{ (hasKey .Values.backup "keepBackupFiles" | ternary .Values.backup.keepBackupFiles true) | toString | quote }}
                 - name: PAGE_CACHE
                   value: {{ .Values.backup.pageCache | trim }}
                 - name: HEAP_SIZE

--- a/neo4j-admin/templates/neo4j-cronjob.yaml
+++ b/neo4j-admin/templates/neo4j-cronjob.yaml
@@ -68,7 +68,7 @@ spec:
                 - name: BUCKET_NAME
                   value: {{ .Values.backup.bucketName | trim }}
                 - name: KEEP_BACKUP_FILES
-                  value: "{{ .Values.backup.keepBackupFiles | default true }}"
+                  value: {{ (hasKey .Values.backup "keepBackupFiles" | ternary .Values.backup.keepBackupFiles true) | toString}}
                 - name: PAGE_CACHE
                   value: {{ .Values.backup.pageCache | trim }}
                 - name: HEAP_SIZE


### PR DESCRIPTION
Use hasKey check to preserve explicitly set `false` values and ensure default `true` only applies when unset. 
Fixes incorrect fallback behavior in Helm templates.