### PR TITLE
Add lb name suffix

### DIFF
--- a/neo4j-loadbalancer/templates/NOTES.txt
+++ b/neo4j-loadbalancer/templates/NOTES.txt
@@ -11,6 +11,6 @@ You have updated {{ .Chart.Name }} in namespace "{{ .Release.Namespace }}".
 {{ end -}}
 
 To view the status of your Load Balancer service you can use
-  $ kubectl get service -n {{ .Release.Namespace }} {{ .Release.Name }}-lb-neo4j
+  $ kubectl get service -n {{ .Release.Namespace }} {{ include "neo4j.name" . }}-{{ .Values.serviceName.suffix | default "lb-neo4j" }}
 
 Once your Load Balancer has an External-IP assigned you can connect to your Neo4j cluster using "neo4j://<EXTERNAL-IP>:7474".

--- a/neo4j-loadbalancer/templates/neo4j-svc.yaml
+++ b/neo4j-loadbalancer/templates/neo4j-svc.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ include "neo4j.name" $ }}-lb-neo4j"
+  name: "{{ include "neo4j.name" $ }}-{{ .Values.serviceName.suffix | default "lb-neo4j" }}"
   namespace: "{{ .Release.Namespace }}"
   labels:
     helm.neo4j.com/neo4j.name: "{{ template "neo4j.name" $ }}"

--- a/neo4j-loadbalancer/values.yaml
+++ b/neo4j-loadbalancer/values.yaml
@@ -4,6 +4,13 @@ neo4j:
   name: "neo4j-loadbalancer"
   edition: "enterprise"
 
+# Service name configuration
+serviceName:
+  # Suffix for the load balancer service name. 
+  # The full service name will be: {{ neo4j.name }}-{{ suffix }}
+  # This allows multiple load balancers in the same namespace when using different suffixes
+  suffix: "lb-neo4j"
+
 # Annotations for the external service
 annotations: { }
 


### PR DESCRIPTION
Enabling the possibility to customize lb-name by adding a suffix. This will make possible deploying multiple loadbalancers in the same namespace.