### PR TITLE
Update _image.tpl for bugfix to allow override of .Values.services.ne…

### DIFF
--- a/neo4j/templates/_image.tpl
+++ b/neo4j/templates/_image.tpl
@@ -33,7 +33,7 @@
     {{- $separator := ":" -}}
     {{- $termination := printf "%s.%s" $.Capabilities.KubeVersion.Major (regexReplaceAll "\\D+" $.Capabilities.KubeVersion.Minor "") -}}
     {{- if not (empty (.tag | trim)) -}}
-        {{- $termination := .tag | toString -}}
+        {{- $termination = .tag | toString -}}
     {{- end -}}
     {{- if .digest }}
         {{- $separator = "@" -}}


### PR DESCRIPTION
…o4j.cleanup.image.tag

Fix for "Capabilities.KubeVersion.Major" that is not allowing override of .Values.services.neo4j.cleanup.image.tag

This fixes bug 454 https://github.com/neo4j/helm-charts/issues/454

I am not sure how the propagation to other branches or even which branches should have this change.