### PR TITLE
Configurable consistency check timeout

### DIFF
--- a/internal/model/backup_values.go
+++ b/internal/model/backup_values.go
@@ -125,6 +125,7 @@ type ConsistencyCheck struct {
 	Threads             string `yaml:"threads,omitempty"`
 	Verbose             bool   `yaml:"verbose" default:"true"`
 	TempDir             string `yaml:"tempDir,omitempty"`
+	Timeout             string `yaml:"timeout,omitempty"`
 }
 
 type Toleration struct {

--- a/internal/unit_tests/helm_template_backup_test.go
+++ b/internal/unit_tests/helm_template_backup_test.go
@@ -1372,3 +1372,69 @@ func TestBackupWithRegistryAndPullSecrets(t *testing.T) {
 	assert.Len(t, pullSecrets, 1)
 	assert.Equal(t, "my-pull-secret", pullSecrets[0].Name)
 }
+
+// TestConsistencyCheckTimeoutDefaultValue checks that the default timeout is set correctly for cloud storage
+func TestConsistencyCheckTimeoutDefaultValue(t *testing.T) {
+	t.Parallel()
+
+	helmValues := model.DefaultNeo4jBackupValues
+	helmValues.DisableLookups = true
+	helmValues.Backup.SecretName = "demo"
+	helmValues.Backup.SecretKeyName = "credentials"
+	helmValues.Backup.CloudProvider = "aws"
+	helmValues.Backup.BucketName = "test-bucket"
+	helmValues.Backup.DatabaseAdminServiceName = "admin"
+	helmValues.Backup.Database = "neo4j"
+	helmValues.ConsistencyCheck.Enable = true
+	// timeout not specified - should default to "30m" for cloud storage
+
+	manifests, err := model.HelmTemplateFromStruct(t, model.BackupHelmChart, helmValues)
+	assert.NoError(t, err)
+
+	cronjobs := manifests.OfType(&batchv1.CronJob{})
+	assert.Len(t, cronjobs, 1)
+
+	envVars := cronjobs[0].(*batchv1.CronJob).Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env
+	var found bool
+	for _, env := range envVars {
+		if env.Name == "CONSISTENCY_CHECK_TIMEOUT" {
+			found = true
+			assert.Equal(t, "30m", env.Value, "Expected CONSISTENCY_CHECK_TIMEOUT to default to 30m for cloud storage")
+			break
+		}
+	}
+	assert.True(t, found, "CONSISTENCY_CHECK_TIMEOUT env var not found")
+}
+
+// TestConsistencyCheckTimeoutCustomValue checks that a custom timeout value is set correctly
+func TestConsistencyCheckTimeoutCustomValue(t *testing.T) {
+	t.Parallel()
+
+	helmValues := model.DefaultNeo4jBackupValues
+	helmValues.DisableLookups = true
+	helmValues.Backup.SecretName = "demo"
+	helmValues.Backup.SecretKeyName = "credentials"
+	helmValues.Backup.CloudProvider = "aws"
+	helmValues.Backup.BucketName = "test-bucket"
+	helmValues.Backup.DatabaseAdminServiceName = "admin"
+	helmValues.Backup.Database = "neo4j"
+	helmValues.ConsistencyCheck.Enable = true
+	helmValues.ConsistencyCheck.Timeout = "2h"
+
+	manifests, err := model.HelmTemplateFromStruct(t, model.BackupHelmChart, helmValues)
+	assert.NoError(t, err)
+
+	cronjobs := manifests.OfType(&batchv1.CronJob{})
+	assert.Len(t, cronjobs, 1)
+
+	envVars := cronjobs[0].(*batchv1.CronJob).Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env
+	var found bool
+	for _, env := range envVars {
+		if env.Name == "CONSISTENCY_CHECK_TIMEOUT" {
+			found = true
+			assert.Equal(t, "2h", env.Value, "Expected CONSISTENCY_CHECK_TIMEOUT to be set to custom value 2h")
+			break
+		}
+	}
+	assert.True(t, found, "CONSISTENCY_CHECK_TIMEOUT env var not found")
+}

--- a/neo4j-admin/backup/neo4j-admin/operations.go
+++ b/neo4j-admin/backup/neo4j-admin/operations.go
@@ -241,13 +241,42 @@ func PerformConsistencyCheck(database string, backupFileName string) (string, er
 	log.Printf("Backup file name: %s", fileName)
 	log.Printf("Cloud provider: %s", cloudProvider)
 
-	// Increase timeout to 30 minutes for cloud storage consistency checks
-	timeout := 30 * time.Minute
-	if cloudProvider != "" {
-		log.Printf("Using extended timeout of %v for cloud storage consistency check", timeout)
-	}
+	// Set timeout for consistency checks - configurable via CONSISTENCY_CHECK_TIMEOUT environment variable
+	// Empty string means no timeout (for local storage)
+	var ctx context.Context
+	var cancel context.CancelFunc
+	var timeoutDuration time.Duration
 
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	timeoutEnv := os.Getenv("CONSISTENCY_CHECK_TIMEOUT")
+	if timeoutEnv != "" {
+		// Parse and apply timeout
+		if parsedTimeout, err := time.ParseDuration(timeoutEnv); err != nil {
+			// Invalid format - use default 30m for cloud, no timeout for local
+			if cloudProvider != "" {
+				timeoutDuration = 30 * time.Minute
+				log.Printf("Warning: Invalid timeout format '%s', using default 30m: %v", timeoutEnv, err)
+				ctx, cancel = context.WithTimeout(context.Background(), timeoutDuration)
+			} else {
+				log.Printf("Warning: Invalid timeout format '%s', no timeout applied for local storage: %v", timeoutEnv, err)
+				ctx, cancel = context.WithCancel(context.Background())
+			}
+		} else {
+			// Valid timeout provided
+			timeoutDuration = parsedTimeout
+			log.Printf("Using configured timeout of %v for consistency check", timeoutDuration)
+			ctx, cancel = context.WithTimeout(context.Background(), timeoutDuration)
+		}
+	} else {
+		// No timeout specified - use default for cloud, none for local
+		if cloudProvider != "" {
+			timeoutDuration = 30 * time.Minute
+			log.Printf("Using default extended timeout of %v for cloud storage consistency check", timeoutDuration)
+			ctx, cancel = context.WithTimeout(context.Background(), timeoutDuration)
+		} else {
+			log.Printf("No timeout applied for local storage consistency check")
+			ctx, cancel = context.WithCancel(context.Background())
+		}
+	}
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "neo4j-admin", flags...)
@@ -314,7 +343,7 @@ func PerformConsistencyCheck(database string, backupFileName string) (string, er
 	log.Printf("Consistency check output: %s", outputBuffer.String())
 
 	if ctx.Err() == context.DeadlineExceeded {
-		return "", fmt.Errorf("Consistency check timed out after %v for database %s", timeout, database)
+		return "", fmt.Errorf("Consistency check timed out after %v for database %s", timeoutDuration, database)
 	}
 
 	if err == nil {

--- a/neo4j-admin/templates/_validation.tpl
+++ b/neo4j-admin/templates/_validation.tpl
@@ -85,7 +85,7 @@
             {{- fail (printf "Invalid timeout format '%s'. Must be a valid Go duration (e.g., '30m', '1h', '2h30m', '1.5h', '4h')" $timeout) -}}
         {{- end -}}
         {{/* Return the provided timeout */}}
-        {{- $timeout }}
+        {{- $timeout | trim -}}
     {{- else -}}
         {{/* Apply conditional default based on cloudProvider */}}
         {{- if .Values.backup.cloudProvider -}}

--- a/neo4j-admin/templates/_validation.tpl
+++ b/neo4j-admin/templates/_validation.tpl
@@ -79,19 +79,15 @@
 {{- define "neo4j.backup.validateAndSetTimeout" -}}
     {{- $timeout := .Values.consistencyCheck.timeout | default "" -}}
     {{- if $timeout -}}
-        {{/* Validate timeout format using regex for Go duration format */}}
-        {{/* Supports compound durations like "2h30m" and decimal values like "1.5h" */}}
+        {{- /* Validate timeout format using regex for Go duration format */ -}}
+        {{- /* Supports compound durations like "2h30m" and decimal values like "1.5h" */ -}}
         {{- if not (regexMatch "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$" $timeout) -}}
             {{- fail (printf "Invalid timeout format '%s'. Must be a valid Go duration (e.g., '30m', '1h', '2h30m', '1.5h', '4h')" $timeout) -}}
         {{- end -}}
-        {{/* Return the provided timeout */}}
-        {{- $timeout | trim -}}
+        {{- /* Return the provided timeout */ -}}
+        {{- $timeout -}}
     {{- else -}}
-        {{/* Apply conditional default based on cloudProvider */}}
-        {{- if .Values.backup.cloudProvider -}}
-            30m
-        {{- else -}}
-            {{/* No timeout for local storage */}}
-        {{- end -}}
+        {{- /* Apply conditional default based on cloudProvider */ -}}
+        {{- if .Values.backup.cloudProvider }}30m{{- else }}{{- /* No timeout for local storage */ -}}{{- end -}}
     {{- end -}}
 {{- end -}}

--- a/neo4j-admin/templates/_validation.tpl
+++ b/neo4j-admin/templates/_validation.tpl
@@ -74,3 +74,24 @@
     {{- end -}}
 
 {{- end -}}
+
+{{/* Validate and set default timeout for consistency check */}}
+{{- define "neo4j.backup.validateAndSetTimeout" -}}
+    {{- $timeout := .Values.consistencyCheck.timeout | default "" -}}
+    {{- if $timeout -}}
+        {{/* Validate timeout format using regex for Go duration format */}}
+        {{/* Supports compound durations like "2h30m" and decimal values like "1.5h" */}}
+        {{- if not (regexMatch "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$" $timeout) -}}
+            {{- fail (printf "Invalid timeout format '%s'. Must be a valid Go duration (e.g., '30m', '1h', '2h30m', '1.5h', '4h')" $timeout) -}}
+        {{- end -}}
+        {{/* Return the provided timeout */}}
+        {{- $timeout -}}
+    {{- else -}}
+        {{/* Apply conditional default based on cloudProvider */}}
+        {{- if .Values.backup.cloudProvider -}}
+            30m
+        {{- else -}}
+            {{/* No timeout for local storage */}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}

--- a/neo4j-admin/templates/_validation.tpl
+++ b/neo4j-admin/templates/_validation.tpl
@@ -85,7 +85,7 @@
             {{- fail (printf "Invalid timeout format '%s'. Must be a valid Go duration (e.g., '30m', '1h', '2h30m', '1.5h', '4h')" $timeout) -}}
         {{- end -}}
         {{/* Return the provided timeout */}}
-        {{- $timeout -}}
+        {{- $timeout }}
     {{- else -}}
         {{/* Apply conditional default based on cloudProvider */}}
         {{- if .Values.backup.cloudProvider -}}

--- a/neo4j-admin/templates/neo4j-cronjob.yaml
+++ b/neo4j-admin/templates/neo4j-cronjob.yaml
@@ -171,6 +171,8 @@ spec:
                   value: {{ .Values.consistencyCheck.verbose | toString | quote | default true }}
                 - name: CONSISTENCY_CHECK_TEMP_DIR
                   value: {{ .Values.consistencyCheck.tempDir | default "" | quote }}
+                - name: CONSISTENCY_CHECK_TIMEOUT
+                  value: {{ include "neo4j.backup.validateAndSetTimeout" . | quote }}
                 - name: AGGREGATE_BACKUP_ENABLED
                   value: {{ .Values.backup.aggregate.enabled | toString | quote | default false }}
                 - name: AGGREGATE_BACKUP_VERBOSE

--- a/neo4j-admin/values.yaml
+++ b/neo4j-admin/values.yaml
@@ -241,6 +241,13 @@ consistencyCheck:
   # Optional temporary directory for consistency check process when using cloud storage
   # If not specified, will use the backup directory with a "consistency-temp" subdirectory
   tempDir: ""
+  # Timeout for consistency check operations
+  # Must be a valid Go duration format (supports compound durations and decimals)
+  # Examples: "30m", "1h", "90m", "2h", "2h30m", "1.5h", "4h"
+  # Helm validation will fail immediately for invalid formats
+  # Default: "30m" for cloud storage (aws/gcp/azure), no timeout for local storage
+  # For large databases, increase this value (e.g., "2h", "4h", "6h")
+  timeout: ""
 
 # Set to name of an existing Service Account to use if desired
 # Follow the following links for setting up a service account with workload identity


### PR DESCRIPTION
Currently the consistency check timeout value is hardcoded to 30m which causes troubles when running consistency checks on large databases.
Added the option to configure the timeout while keeping the default value at 30m.