### PR TITLE
add .neo4j.developServer flag

### DIFF
--- a/neo4j/templates/_helpers.tpl
+++ b/neo4j/templates/_helpers.tpl
@@ -124,9 +124,11 @@ E.g. by adding `--set podSpec.loadbalancer=include`
 {{ end -}}
 
 {{- define "neo4j.checkResources" -}}
-    {{- template "neo4j.resources.checkForEmptyResources" . -}}
-    {{- template "neo4j.resources.evaluateCPU" . -}}
-    {{- template "neo4j.resources.evaluateMemory" . -}}
+    {{- if not .Values.neo4j.developServer -}} 
+        {{- template "neo4j.resources.checkForEmptyResources" . -}}
+        {{- template "neo4j.resources.evaluateCPU" . -}}
+        {{- template "neo4j.resources.evaluateMemory" . -}}
+    {{- end -}} 
 {{- end -}}
 
 {{/* checks if the resources are empty or not */}}


### PR DESCRIPTION
Add .neo4j.developServer flag to disable resource checks.
To be used in feature environments where we do not need performance.