### PR TITLE
Enable reverse proxy namespace

### DIFF
--- a/internal/unit_tests/helm_template_reverseproxy_test.go
+++ b/internal/unit_tests/helm_template_reverseproxy_test.go
@@ -2,10 +2,13 @@ package unit_tests
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/neo4j/helm-charts/internal/model"
 	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/networking/v1"
-	"testing"
 )
 
 // TestReverseProxyIngressWithAnnotations checks whether ingress has the provided annotations or not
@@ -110,4 +113,64 @@ func TestReverseProxyIngressHostName(t *testing.T) {
 	assert.Len(t, ingressList, 1, fmt.Sprintf("number of ingress should be 1 , not equal with %d", len(ingressList)))
 	ingressHostName := ingressList[0].(*v1.Ingress).Spec.Rules[0].Host
 	assert.Equal(t, ingressHostName, "demo.com", "ingress hostname not matching")
+}
+
+// TestReverseProxyNamespaceParameter checks if namespace parameter is correctly passed to the deployment
+func TestReverseProxyNamespaceParameter(t *testing.T) {
+	t.Parallel()
+
+	helmValues := model.DefaultNeo4jReverseProxyValues
+	helmValues.ReverseProxy.Namespace = "neo4j-production"
+	helmValues.ReverseProxy.ServiceName = "neo4j-service"
+	manifests, err := model.HelmTemplateFromStruct(t, model.ReverseProxyHelmChart, helmValues)
+	assert.NoError(t, err, "error seen while testing namespace parameter with reverse proxy helm chart")
+
+	deploymentList := manifests.OfType(&appsv1.Deployment{})
+	assert.Len(t, deploymentList, 1, fmt.Sprintf("number of deployments should be 1, not %d", len(deploymentList)))
+
+	deployment := deploymentList[0].(*appsv1.Deployment)
+	containers := deployment.Spec.Template.Spec.Containers
+	assert.Len(t, containers, 1, "should have exactly one container")
+
+	// Check if NAMESPACE env var is set to the custom namespace
+	var namespaceEnv *corev1.EnvVar
+	for _, env := range containers[0].Env {
+		if env.Name == "NAMESPACE" {
+			namespaceEnv = &env
+			break
+		}
+	}
+
+	assert.NotNil(t, namespaceEnv, "NAMESPACE environment variable should be set")
+	assert.Equal(t, "neo4j-production", namespaceEnv.Value, "NAMESPACE should be set to the custom namespace")
+}
+
+// TestReverseProxyNamespaceDefaultsToReleaseNamespace checks backward compatibility when namespace is not specified
+func TestReverseProxyNamespaceDefaultsToReleaseNamespace(t *testing.T) {
+	t.Parallel()
+
+	helmValues := model.DefaultNeo4jReverseProxyValues
+	helmValues.ReverseProxy.Namespace = "" // explicitly empty to test default behavior
+	helmValues.ReverseProxy.ServiceName = "neo4j-service"
+	manifests, err := model.HelmTemplateFromStruct(t, model.ReverseProxyHelmChart, helmValues, "--namespace", "reverse-proxy-ns")
+	assert.NoError(t, err, "error seen while testing default namespace with reverse proxy helm chart")
+
+	deploymentList := manifests.OfType(&appsv1.Deployment{})
+	assert.Len(t, deploymentList, 1, fmt.Sprintf("number of deployments should be 1, not %d", len(deploymentList)))
+
+	deployment := deploymentList[0].(*appsv1.Deployment)
+	containers := deployment.Spec.Template.Spec.Containers
+	assert.Len(t, containers, 1, "should have exactly one container")
+
+	// Check if NAMESPACE env var defaults to the release namespace
+	var namespaceEnv *corev1.EnvVar
+	for _, env := range containers[0].Env {
+		if env.Name == "NAMESPACE" {
+			namespaceEnv = &env
+			break
+		}
+	}
+
+	assert.NotNil(t, namespaceEnv, "NAMESPACE environment variable should be set")
+	assert.Equal(t, "reverse-proxy-ns", namespaceEnv.Value, "NAMESPACE should default to the release namespace")
 }

--- a/neo4j-reverse-proxy/templates/reverseProxyServer.yaml
+++ b/neo4j-reverse-proxy/templates/reverseProxyServer.yaml
@@ -33,7 +33,7 @@ spec:
             - name: DOMAIN
               value: {{ $.Values.reverseProxy.domain | default "cluster.local" }}
             - name: NAMESPACE
-              value: {{ .Release.Namespace }}
+              value: {{ $.Values.reverseProxy.namespace | default .Release.Namespace }}
 ---
 apiVersion: v1
 kind: Service

--- a/neo4j-reverse-proxy/values.yaml
+++ b/neo4j-reverse-proxy/values.yaml
@@ -15,6 +15,9 @@ reverseProxy:
   # When used against a cluster ensure the service being used is pointing to all the cluster instances.
   # This could be the loadbalancer from neo4j helm chart or the headless service installed via neo4j-headless-service helm chart
   serviceName: ""
+  # Namespace where the Neo4j service is running. If not specified, defaults to the namespace where the reverse proxy is installed.
+  # This allows installing the reverse proxy in one namespace while connecting to Neo4j in another namespace.
+  namespace: ""
   # default is set to cluster.local
   domain: "cluster.local"
 


### PR DESCRIPTION
## Add Namespace Parameter for reverse-proxy

### Summary
Adds `reverseProxy.namespace` parameter to allow the reverse proxy deployment in a custom namespace.

### Changes
- Added `namespace` parameter to `values.yaml`
- Updated `reverseProxyServer.yaml` template to use custom namespace when provided
- Defaults to `.Release.Namespace` for backward compatibility
- Added unit tests for both custom and default namespace behavior
