### PR TITLE
Add support for remote-address-resolution flag in k8s backups

### DIFF
--- a/neo4j-admin/backup/neo4j-admin/helpers.go
+++ b/neo4j-admin/backup/neo4j-admin/helpers.go
@@ -91,6 +91,18 @@ func getBackupCommandFlags(address string) []string {
 		flags = append(flags, "--verbose")
 	}
 
+	// Support for remote address resolution flag introduced in Neo4j 2025.09
+	// If REMOTE_ADDRESS_RESOLUTION is set, pass it through to neo4j-admin.
+	// - If the value is exactly "true", add the flag without an explicit value (boolean flag)
+	// - Otherwise, pass the value as --remote-address-resolution=<value>
+	if rar := os.Getenv("REMOTE_ADDRESS_RESOLUTION"); len(strings.TrimSpace(rar)) > 0 {
+		if strings.EqualFold(strings.TrimSpace(rar), "true") {
+			flags = append(flags, "--remote-address-resolution")
+		} else {
+			flags = append(flags, fmt.Sprintf("--remote-address-resolution=%s", strings.TrimSpace(rar)))
+		}
+	}
+
 	for _, db := range strings.Split(os.Getenv("DATABASE"), ",") {
 		flags = append(flags, strings.TrimSpace(db))
 	}

--- a/neo4j-admin/templates/neo4j-cronjob.yaml
+++ b/neo4j-admin/templates/neo4j-cronjob.yaml
@@ -113,6 +113,8 @@ spec:
                   value: {{ .Values.backup.verbose | toString | quote | default true }}
                 - name: COMPRESS
                   value: {{ .Values.backup.compress | toString | quote | default true }}
+                - name: REMOTE_ADDRESS_RESOLUTION
+                  value: {{ .Values.backup.remoteAddressResolution | toString | quote | default false }}
                 - name: AZURE_STORAGE_ACCOUNT
                   value: "{{ .Values.backup.azureStorageAccountName | default "" }}"
                 - name: BACKUP_TEMP_DIR

--- a/neo4j-admin/values.yaml
+++ b/neo4j-admin/values.yaml
@@ -188,6 +188,12 @@ backup:
   verbose: true
   heapSize: ""
   compress: true
+  
+  # Remote address resolution flag (Neo4j 2025.09+)
+  # Controls how backup endpoints resolve remote addresses
+  # Set to true to enable, false to disable (default), or provide a specific mode value
+  # See: https://neo4j.com/docs/operations-manual/current/backup-restore/online-backup/#_using_remote_address_resolution
+  remoteAddressResolution: false
 
   # Neo4j Native Cloud Storage Features
   # Enable differential backups - allows Neo4j to create differential backups directly to cloud storage


### PR DESCRIPTION
- Added REMOTE_ADDRESS_RESOLUTION environment variable support in Go backup logic
- Updated Helm chart values.yaml to expose remoteAddressResolution config (default: false)
- Updated neo4j-cronjob.yaml template to pass the flag to backup containers
- Supports Neo4j 2025.09+ remote address resolution feature

Fixes #497