### PR TITLE
enable image pull secrets

### DIFF
--- a/internal/model/reverse_proxy_values.go
+++ b/internal/model/reverse_proxy_values.go
@@ -7,11 +7,12 @@ type Neo4jReverseProxyValues struct {
 }
 
 type ReverseProxy struct {
-	Image       string  `yaml:"image,omitempty"`
-	ServiceName string  `yaml:"serviceName,omitempty"`
-	Namespace   string  `yaml:"namespace,omitempty"`
-	Domain      string  `yaml:"domain,omitempty"`
-	Ingress     Ingress `yaml:"ingress,omitempty"`
+	Image            string   `yaml:"image,omitempty"`
+	ImagePullSecrets []string `yaml:"imagePullSecrets,omitempty"`
+	ServiceName      string   `yaml:"serviceName,omitempty"`
+	Namespace        string   `yaml:"namespace,omitempty"`
+	Domain           string   `yaml:"domain,omitempty"`
+	Ingress          Ingress  `yaml:"ingress,omitempty"`
 }
 
 type Ingress struct {

--- a/internal/unit_tests/helm_template_neo4j_operations_test.go
+++ b/internal/unit_tests/helm_template_neo4j_operations_test.go
@@ -172,3 +172,67 @@ func TestNeo4jOperationsEnableServerForStandalone(t *testing.T) {
 	assert.Nil(t, operationsRole, "operations role should not be present for standalone")
 
 }
+
+// TestNeo4jOperationsImagePullSecrets tests that imagePullSecrets are correctly set in the operations pod
+func TestNeo4jOperationsImagePullSecrets(t *testing.T) {
+	t.Parallel()
+
+	clusterSize := 3
+	helmValues := model.DefaultEnterpriseValues
+	helmValues.DisableLookups = true
+	helmValues.Neo4J.MinimumClusterSize = clusterSize
+	helmValues.Image.ImagePullSecrets = []string{"my-pull-secret", "another-secret"}
+	operations := model.Operations{
+		EnableServer: true,
+		Image:        "demo:123",
+		Protocol:     "neo4j",
+	}
+	helmValues.Neo4J.Operations = operations
+
+	manifest, err := model.HelmTemplateFromStruct(t, model.HelmChart, helmValues)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	operationsPod := manifest.OfTypeWithName(
+		&v1.Pod{},
+		fmt.Sprintf("%s-operations", model.DefaultHelmTemplateReleaseName.String()),
+	).(*v1.Pod)
+	assert.NotNil(t, operationsPod, "operations pod not found")
+
+	pullSecrets := operationsPod.Spec.ImagePullSecrets
+	assert.Len(t, pullSecrets, 2, "should have 2 imagePullSecrets")
+	assert.Equal(t, "my-pull-secret", pullSecrets[0].Name)
+	assert.Equal(t, "another-secret", pullSecrets[1].Name)
+}
+
+// TestNeo4jOperationsImagePullSecretsEmpty tests that empty imagePullSecrets are handled correctly
+func TestNeo4jOperationsImagePullSecretsEmpty(t *testing.T) {
+	t.Parallel()
+
+	clusterSize := 3
+	helmValues := model.DefaultEnterpriseValues
+	helmValues.DisableLookups = true
+	helmValues.Neo4J.MinimumClusterSize = clusterSize
+	helmValues.Image.ImagePullSecrets = []string{}
+	operations := model.Operations{
+		EnableServer: true,
+		Image:        "demo:123",
+		Protocol:     "neo4j",
+	}
+	helmValues.Neo4J.Operations = operations
+
+	manifest, err := model.HelmTemplateFromStruct(t, model.HelmChart, helmValues)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	operationsPod := manifest.OfTypeWithName(
+		&v1.Pod{},
+		fmt.Sprintf("%s-operations", model.DefaultHelmTemplateReleaseName.String()),
+	).(*v1.Pod)
+	assert.NotNil(t, operationsPod, "operations pod not found")
+
+	pullSecrets := operationsPod.Spec.ImagePullSecrets
+	assert.Nil(t, pullSecrets, "imagePullSecrets should be nil when empty")
+}

--- a/internal/unit_tests/helm_template_primaries_test.go
+++ b/internal/unit_tests/helm_template_primaries_test.go
@@ -2616,3 +2616,74 @@ func TestCleanupJobLabels(t *testing.T) {
 		assert.Equal(t, model.DefaultHelmTemplateReleaseName.String(), saLabels["helm.neo4j.com/instance"], "incorrect service account instance label")
 	}))
 }
+
+// TestCleanupJobImagePullSecrets tests that imagePullSecrets are correctly set in the cleanup job
+func TestCleanupJobImagePullSecrets(t *testing.T) {
+	t.Parallel()
+
+	forEachPrimaryChart(t, andEachSupportedEdition(func(t *testing.T, chart model.Neo4jHelmChartBuilder, edition string) {
+		if edition != "enterprise" {
+			return // Skip test for non-enterprise edition since cleanup job is enterprise-only
+		}
+
+		helmValues := model.DefaultEnterpriseValues
+		helmValues.DisableLookups = true
+		helmValues.Image.ImagePullSecrets = []string{"my-pull-secret", "another-secret"}
+
+		manifest, err := model.HelmTemplate(t, chart, []string{
+			"--set", "neo4j.name=" + model.DefaultNeo4jName,
+			"--set", "neo4j.minimumClusterSize=3",
+			"--set", "neo4j.edition=enterprise",
+			"--set", "neo4j.acceptLicenseAgreement=yes",
+			"--set", "services.neo4j.cleanup.enabled=true",
+			"--set", "disableLookups=true",
+			"--set", "image.imagePullSecrets[0]=my-pull-secret",
+			"--set", "image.imagePullSecrets[1]=another-secret",
+			"--set", "volumes.data.mode=selector",
+		})
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		cleanupJob := manifest.OfTypeWithName(&batchv1.Job{}, fmt.Sprintf("%s-cleanup", model.DefaultHelmTemplateReleaseName))
+		if !assert.NotNil(t, cleanupJob, "cleanup job not found") {
+			return
+		}
+
+		pullSecrets := cleanupJob.(*batchv1.Job).Spec.Template.Spec.ImagePullSecrets
+		assert.Len(t, pullSecrets, 2, "should have 2 imagePullSecrets")
+		assert.Equal(t, "my-pull-secret", pullSecrets[0].Name)
+		assert.Equal(t, "another-secret", pullSecrets[1].Name)
+	}))
+}
+
+// TestCleanupJobImagePullSecretsEmpty tests that empty imagePullSecrets are handled correctly in cleanup job
+func TestCleanupJobImagePullSecretsEmpty(t *testing.T) {
+	t.Parallel()
+
+	forEachPrimaryChart(t, andEachSupportedEdition(func(t *testing.T, chart model.Neo4jHelmChartBuilder, edition string) {
+		if edition != "enterprise" {
+			return // Skip test for non-enterprise edition since cleanup job is enterprise-only
+		}
+
+		manifest, err := model.HelmTemplate(t, chart, []string{
+			"--set", "neo4j.name=" + model.DefaultNeo4jName,
+			"--set", "neo4j.minimumClusterSize=3",
+			"--set", "neo4j.edition=enterprise",
+			"--set", "neo4j.acceptLicenseAgreement=yes",
+			"--set", "services.neo4j.cleanup.enabled=true",
+			"--set", "volumes.data.mode=selector",
+		})
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		cleanupJob := manifest.OfTypeWithName(&batchv1.Job{}, fmt.Sprintf("%s-cleanup", model.DefaultHelmTemplateReleaseName))
+		if !assert.NotNil(t, cleanupJob, "cleanup job not found") {
+			return
+		}
+
+		pullSecrets := cleanupJob.(*batchv1.Job).Spec.Template.Spec.ImagePullSecrets
+		assert.Nil(t, pullSecrets, "imagePullSecrets should be nil when empty")
+	}))
+}

--- a/internal/unit_tests/helm_template_reverseproxy_test.go
+++ b/internal/unit_tests/helm_template_reverseproxy_test.go
@@ -174,3 +174,43 @@ func TestReverseProxyNamespaceDefaultsToReleaseNamespace(t *testing.T) {
 	assert.NotNil(t, namespaceEnv, "NAMESPACE environment variable should be set")
 	assert.Equal(t, "reverse-proxy-ns", namespaceEnv.Value, "NAMESPACE should default to the release namespace")
 }
+
+// TestReverseProxyImagePullSecrets tests that imagePullSecrets are correctly set in the reverse proxy deployment
+func TestReverseProxyImagePullSecrets(t *testing.T) {
+	t.Parallel()
+
+	helmValues := model.DefaultNeo4jReverseProxyValues
+	helmValues.ReverseProxy.ImagePullSecrets = []string{"my-pull-secret", "another-secret"}
+	helmValues.ReverseProxy.ServiceName = "neo4j-service"
+
+	manifests, err := model.HelmTemplateFromStruct(t, model.ReverseProxyHelmChart, helmValues)
+	assert.NoError(t, err, "error seen while testing imagePullSecrets with reverse proxy helm chart")
+
+	deploymentList := manifests.OfType(&appsv1.Deployment{})
+	assert.Len(t, deploymentList, 1, fmt.Sprintf("number of deployments should be 1, not %d", len(deploymentList)))
+
+	deployment := deploymentList[0].(*appsv1.Deployment)
+	pullSecrets := deployment.Spec.Template.Spec.ImagePullSecrets
+	assert.Len(t, pullSecrets, 2, "should have 2 imagePullSecrets")
+	assert.Equal(t, "my-pull-secret", pullSecrets[0].Name)
+	assert.Equal(t, "another-secret", pullSecrets[1].Name)
+}
+
+// TestReverseProxyImagePullSecretsEmpty tests that empty imagePullSecrets are handled correctly
+func TestReverseProxyImagePullSecretsEmpty(t *testing.T) {
+	t.Parallel()
+
+	helmValues := model.DefaultNeo4jReverseProxyValues
+	helmValues.ReverseProxy.ImagePullSecrets = []string{}
+	helmValues.ReverseProxy.ServiceName = "neo4j-service"
+
+	manifests, err := model.HelmTemplateFromStruct(t, model.ReverseProxyHelmChart, helmValues)
+	assert.NoError(t, err, "error seen while testing empty imagePullSecrets with reverse proxy helm chart")
+
+	deploymentList := manifests.OfType(&appsv1.Deployment{})
+	assert.Len(t, deploymentList, 1, fmt.Sprintf("number of deployments should be 1, not %d", len(deploymentList)))
+
+	deployment := deploymentList[0].(*appsv1.Deployment)
+	pullSecrets := deployment.Spec.Template.Spec.ImagePullSecrets
+	assert.Nil(t, pullSecrets, "imagePullSecrets should be nil when empty")
+}

--- a/neo4j-reverse-proxy/templates/reverseProxyServer.yaml
+++ b/neo4j-reverse-proxy/templates/reverseProxyServer.yaml
@@ -18,6 +18,12 @@ spec:
         name: {{ include "neo4j.fullname" . }}-reverseproxy
     spec:
       securityContext: {{ toYaml .Values.reverseProxy.podSecurityContext | nindent 8 }}
+      {{- if .Values.reverseProxy.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.reverseProxy.imagePullSecrets }}
+      - name: {{ . }}
+      {{- end }}
+      {{- end }}
       containers:
         - name: {{ include "neo4j.fullname" . }}-reverseproxy
           image: {{ $.Values.reverseProxy.image }}

--- a/neo4j-reverse-proxy/values.yaml
+++ b/neo4j-reverse-proxy/values.yaml
@@ -9,6 +9,10 @@ fullnameOverride: ""
 reverseProxy:
   image: "neo4j/helm-charts-reverse-proxy:2025.10.1-1"
 
+  # imagePullSecrets for pulling the reverse proxy image from private registries
+  imagePullSecrets: []
+  #  - name: my-docker-secret
+
   # Name of the kubernetes service. This service should have the ports 7474 and 7687 open.
   # This could be the admin service ex: "standalone-admin" or the loadbalancer service ex: "standalone" created via the neo4j helm chart
   # serviceName , namespace , domain together will form the complete k8s service url. Ex: standalone-admin.default.svc.cluster.local

--- a/neo4j/templates/delete-loadbalancer-hook.yaml
+++ b/neo4j/templates/delete-loadbalancer-hook.yaml
@@ -31,6 +31,7 @@ spec:
         helm.neo4j.com/instance: "{{ include "neo4j.fullname" . }}"
     spec:
       serviceAccountName: "{{ include "neo4j.fullname" . }}-cleanup"
+      {{- include "neo4j.imagePullSecrets" .Values.image.imagePullSecrets | indent 6 }}
       containers:
         - name: kubectl
           image: "{{ include "cleanup.image" . }}"

--- a/neo4j/templates/neo4j-operations.yaml
+++ b/neo4j/templates/neo4j-operations.yaml
@@ -11,6 +11,7 @@ metadata:
 spec:
   restartPolicy: Never
   serviceAccountName: {{ include "neo4j.serviceAccountName" . }}
+  {{- include "neo4j.imagePullSecrets" .Values.image.imagePullSecrets | indent 2 }}
   containers:
     - name: {{ include "neo4j.fullname" . }}-operations
       image: {{ $.Values.neo4j.operations.image }}


### PR DESCRIPTION
Add imagePullSecrets support across all the charts(reverse-proxy, operations, lb-cleanup)

Fixes #464 