### PR TITLE
Fixed Azure GovCloud endpoint support in countAzureBackups function

### DIFF
--- a/neo4j-admin/backup/neo4j-admin/operations.go
+++ b/neo4j-admin/backup/neo4j-admin/operations.go
@@ -496,7 +496,12 @@ func countAzureBackups(db, account, containerPath string) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	serviceURL := fmt.Sprintf("https://%s.blob.core.windows.net", storageAccount)
+	// Use AZURE_BLOB_SERVICE_URL if provided (for GovCloud support), otherwise default to commercial Azure
+	blobServiceURL := os.Getenv("AZURE_BLOB_SERVICE_URL")
+	if blobServiceURL == "" {
+		blobServiceURL = "blob.core.windows.net"
+	}
+	serviceURL := fmt.Sprintf("https://%s.%s", storageAccount, blobServiceURL)
 	client, err := azblob.NewClient(serviceURL, cred, nil)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
The `countAzureBackups()` function in `neo4j-admin/backup/neo4j-admin/operations.go` was hardcoded to use the commercial Azure endpoint (`blob.core.windows.net`), causing failures for customers using Azure GovCloud (`blob.core.usgovcloudapi.net`).

This function is used during aggregate backup operations to count existing backups before deciding whether aggregation is needed. When `AZURE_BLOB_SERVICE_URL` was set to a GovCloud endpoint, the function would still attempt to connect to the commercial Azure endpoint, resulting in connection failures.
