### PR TITLE
Add the option to define container resources on the deployment of the reverseProxy

### DIFF
--- a/internal/model/reverse_proxy_values.go
+++ b/internal/model/reverse_proxy_values.go
@@ -7,14 +7,30 @@ type Neo4jReverseProxyValues struct {
 }
 
 type ReverseProxy struct {
-	Image            string            `yaml:"image,omitempty"`
-	ImagePullSecrets []string          `yaml:"imagePullSecrets,omitempty"`
-	ServiceName      string            `yaml:"serviceName,omitempty"`
-	Namespace        string            `yaml:"namespace,omitempty"`
-	Domain           string            `yaml:"domain,omitempty"`
-	Ingress          Ingress           `yaml:"ingress,omitempty"`
-	PodLabels        map[string]string `yaml:"podLabels,omitempty"`
-	NodeSelector     map[string]string `yaml:"nodeSelector,omitempty"`
+	Image            string                `yaml:"image,omitempty"`
+	ImagePullSecrets []string              `yaml:"imagePullSecrets,omitempty"`
+	ServiceName      string                `yaml:"serviceName,omitempty"`
+	Namespace        string                `yaml:"namespace,omitempty"`
+	Domain           string                `yaml:"domain,omitempty"`
+	Ingress          Ingress               `yaml:"ingress,omitempty"`
+	PodLabels        map[string]string     `yaml:"podLabels,omitempty"`
+	NodeSelector     map[string]string     `yaml:"nodeSelector,omitempty"`
+	Resources        ReverseProxyResources `yaml:"resources,omitempty"`
+}
+
+type ReverseProxyResources struct {
+	Requests ReverseProxyRequests `yaml:"requests,omitempty"`
+	Limits   ReverseProxyLimits   `yaml:"limits,omitempty"`
+}
+
+type ReverseProxyRequests struct {
+	CPU    string `yaml:"cpu,omitempty"`
+	Memory string `yaml:"memory,omitempty"`
+}
+
+type ReverseProxyLimits struct {
+	CPU    string `yaml:"cpu,omitempty"`
+	Memory string `yaml:"memory,omitempty"`
 }
 
 type Ingress struct {

--- a/internal/unit_tests/helm_template_reverseproxy_test.go
+++ b/internal/unit_tests/helm_template_reverseproxy_test.go
@@ -314,6 +314,65 @@ func TestReverseProxyImagePullSecrets(t *testing.T) {
 	assert.Equal(t, "another-secret", pullSecrets[1].Name)
 }
 
+// TestReverseProxyResources tests that resource requests and limits are correctly set on the deployment container
+func TestReverseProxyResources(t *testing.T) {
+	t.Parallel()
+
+	helmValues := model.DefaultNeo4jReverseProxyValues
+	helmValues.ReverseProxy.ServiceName = "neo4j-service"
+	helmValues.ReverseProxy.Resources = model.ReverseProxyResources{
+		Requests: model.ReverseProxyRequests{
+			CPU:    "200m",
+			Memory: "256Mi",
+		},
+		Limits: model.ReverseProxyLimits{
+			CPU:    "1000m",
+			Memory: "512Mi",
+		},
+	}
+
+	manifests, err := model.HelmTemplateFromStruct(t, model.ReverseProxyHelmChart, helmValues)
+	assert.NoError(t, err, "error seen while testing resources with reverse proxy helm chart")
+
+	deploymentList := manifests.OfType(&appsv1.Deployment{})
+	assert.Len(t, deploymentList, 1, fmt.Sprintf("number of deployments should be 1, not %d", len(deploymentList)))
+
+	deployment := deploymentList[0].(*appsv1.Deployment)
+	containers := deployment.Spec.Template.Spec.Containers
+	assert.Len(t, containers, 1, "should have exactly one container")
+
+	resources := containers[0].Resources
+	assert.Equal(t, "200m", resources.Requests.Cpu().String(), "CPU request should match")
+	assert.Equal(t, "256Mi", resources.Requests.Memory().String(), "Memory request should match")
+	assert.Equal(t, "1000m", resources.Limits.Cpu().String(), "CPU limit should match")
+	assert.Equal(t, "512Mi", resources.Limits.Memory().String(), "Memory limit should match")
+}
+
+// TestReverseProxyDefaultResources tests that default resource values from values.yaml are applied
+func TestReverseProxyDefaultResources(t *testing.T) {
+	t.Parallel()
+
+	helmValues := model.DefaultNeo4jReverseProxyValues
+	helmValues.ReverseProxy.ServiceName = "neo4j-service"
+	// No explicit resources set — chart defaults should apply
+
+	manifests, err := model.HelmTemplateFromStruct(t, model.ReverseProxyHelmChart, helmValues)
+	assert.NoError(t, err, "error seen while testing default resources with reverse proxy helm chart")
+
+	deploymentList := manifests.OfType(&appsv1.Deployment{})
+	assert.Len(t, deploymentList, 1, fmt.Sprintf("number of deployments should be 1, not %d", len(deploymentList)))
+
+	deployment := deploymentList[0].(*appsv1.Deployment)
+	containers := deployment.Spec.Template.Spec.Containers
+	assert.Len(t, containers, 1, "should have exactly one container")
+
+	resources := containers[0].Resources
+	assert.NotNil(t, resources.Requests, "resource requests should be set by default")
+	assert.NotNil(t, resources.Limits, "resource limits should be set by default")
+	assert.False(t, resources.Requests.Cpu().IsZero(), "default CPU request should not be zero")
+	assert.False(t, resources.Limits.Cpu().IsZero(), "default CPU limit should not be zero")
+}
+
 // TestReverseProxyImagePullSecretsEmpty tests that empty imagePullSecrets are handled correctly
 func TestReverseProxyImagePullSecretsEmpty(t *testing.T) {
 	t.Parallel()

--- a/neo4j-reverse-proxy/templates/reverseProxyServer.yaml
+++ b/neo4j-reverse-proxy/templates/reverseProxyServer.yaml
@@ -42,6 +42,15 @@ spec:
               value: {{ $.Values.reverseProxy.domain | default "cluster.local" }}
             - name: NAMESPACE
               value: {{ $.Values.reverseProxy.namespace | default .Release.Namespace }}
+          {{ - with .Values.reverseProxy.resources }}
+          resources:
+            {{ - if hasKey . "requests" | or (hasKey . "limits") }}
+            {{ - omit . "cpu" "memory" | toYaml | nindent 12 }}
+            {{ - else }}
+            requests: {{ . | toYaml | nindent 14 }}
+            limits: {{ . | toYaml | nindent 14 }}
+            {{ - end }}
+          {{ - end }}
 ---
 apiVersion: v1
 kind: Service

--- a/neo4j-reverse-proxy/templates/reverseProxyServer.yaml
+++ b/neo4j-reverse-proxy/templates/reverseProxyServer.yaml
@@ -42,15 +42,15 @@ spec:
               value: {{ $.Values.reverseProxy.domain | default "cluster.local" }}
             - name: NAMESPACE
               value: {{ $.Values.reverseProxy.namespace | default .Release.Namespace }}
-          {{ - with .Values.reverseProxy.resources }}
+          {{- with .Values.reverseProxy.resources }}
           resources:
-            {{ - if hasKey . "requests" | or (hasKey . "limits") }}
-            {{ - omit . "cpu" "memory" | toYaml | nindent 12 }}
-            {{ - else }}
+            {{- if hasKey . "requests" | or (hasKey . "limits") }}
+            {{- omit . "cpu" "memory" | toYaml | nindent 12 }}
+            {{- else }}
             requests: {{ . | toYaml | nindent 14 }}
             limits: {{ . | toYaml | nindent 14 }}
-            {{ - end }}
-          {{ - end }}
+            {{- end }}
+          {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/neo4j-reverse-proxy/templates/reverseProxyServer.yaml
+++ b/neo4j-reverse-proxy/templates/reverseProxyServer.yaml
@@ -44,7 +44,7 @@ spec:
               value: {{ $.Values.reverseProxy.namespace | default .Release.Namespace }}
           {{- with .Values.reverseProxy.resources }}
           resources:
-            {{- if hasKey . "requests" | or (hasKey . "limits") }}
+            {{- if or (hasKey . "limits") (hasKey . "requests") }}
             {{- omit . "cpu" "memory" | toYaml | nindent 12 }}
             {{- else }}
             requests: {{ . | toYaml | nindent 14 }}

--- a/neo4j-reverse-proxy/values.yaml
+++ b/neo4j-reverse-proxy/values.yaml
@@ -42,14 +42,14 @@ reverseProxy:
     fsGroup: 7474
     fsGroupChangePolicy: "Always"
 
-  # Resources used by the container
-  resources: {}
-  #  request:
-  #    cpu:
-  #    memory:
-  #  limits:
-  #    cpu:
-  #    memory:
+  # Resources used by the container with some default values
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "128Mi"
+    limits:
+      cpu: "500m"
+      memory: "256Mi"
 
   # Pod labels for security policies and workload identification
   podLabels: {}

--- a/neo4j-reverse-proxy/values.yaml
+++ b/neo4j-reverse-proxy/values.yaml
@@ -33,7 +33,7 @@ reverseProxy:
     runAsGroup: 7474
     capabilities:
       drop:
-        - all
+        - ALL
 
   podSecurityContext:
     runAsNonRoot: true

--- a/neo4j-reverse-proxy/values.yaml
+++ b/neo4j-reverse-proxy/values.yaml
@@ -42,6 +42,15 @@ reverseProxy:
     fsGroup: 7474
     fsGroupChangePolicy: "Always"
 
+  # Resources used by the container
+  resources: {}
+  #  request:
+  #    cpu:
+  #    memory:
+  #  limits:
+  #    cpu:
+  #    memory:
+
   # Pod labels for security policies and workload identification
   podLabels: {}
   #  app: "reverse-proxy"


### PR DESCRIPTION
At the moment no resources are defined or the option to add resources is available in the Neo4j reverse proxy helm chart.
This change add the possibility to define this in the values file.