### PR TITLE
Feature/taints tolerations full support

### DIFF
--- a/internal/model/reverse_proxy_values.go
+++ b/internal/model/reverse_proxy_values.go
@@ -15,6 +15,7 @@ type ReverseProxy struct {
 	Ingress          Ingress           `yaml:"ingress,omitempty"`
 	PodLabels        map[string]string `yaml:"podLabels,omitempty"`
 	NodeSelector     map[string]string `yaml:"nodeSelector,omitempty"`
+	Tolerations      []Toleration      `yaml:"tolerations,omitempty"`
 }
 
 type Ingress struct {

--- a/internal/unit_tests/helm_template_reverseproxy_test.go
+++ b/internal/unit_tests/helm_template_reverseproxy_test.go
@@ -293,6 +293,87 @@ func TestReverseProxyEmptyPodLabelsAndNodeSelector(t *testing.T) {
 	assert.Nil(t, nodeSelector, "nodeSelector should not be present when empty")
 }
 
+// TestReverseProxyTolerations checks if tolerations are correctly set on the deployment pod spec
+func TestReverseProxyTolerations(t *testing.T) {
+	t.Parallel()
+
+	dummyToleration := model.Toleration{
+		Key:      "dedicated",
+		Operator: "Equal",
+		Value:    "reverse-proxy",
+		Effect:   "NoSchedule",
+	}
+	helmValues := model.DefaultNeo4jReverseProxyValues
+	helmValues.ReverseProxy.ServiceName = "neo4j-service"
+	helmValues.ReverseProxy.Tolerations = []model.Toleration{dummyToleration}
+
+	manifests, err := model.HelmTemplateFromStruct(t, model.ReverseProxyHelmChart, helmValues)
+	assert.NoError(t, err, "error seen while testing tolerations with reverse proxy helm chart")
+
+	deploymentList := manifests.OfType(&appsv1.Deployment{})
+	assert.Len(t, deploymentList, 1, fmt.Sprintf("number of deployments should be 1, not %d", len(deploymentList)))
+
+	deployment := deploymentList[0].(*appsv1.Deployment)
+	tolerations := deployment.Spec.Template.Spec.Tolerations
+	assert.Len(t, tolerations, 1, "should have exactly one toleration")
+	assert.Equal(t, dummyToleration.Key, tolerations[0].Key, "toleration key should match")
+	assert.Equal(t, dummyToleration.Operator, string(tolerations[0].Operator), "toleration operator should match")
+	assert.Equal(t, dummyToleration.Value, tolerations[0].Value, "toleration value should match")
+	assert.Equal(t, dummyToleration.Effect, string(tolerations[0].Effect), "toleration effect should match")
+}
+
+// TestReverseProxyEmptyTolerations checks that empty tolerations don't break the template
+func TestReverseProxyEmptyTolerations(t *testing.T) {
+	t.Parallel()
+
+	helmValues := model.DefaultNeo4jReverseProxyValues
+	helmValues.ReverseProxy.ServiceName = "neo4j-service"
+	helmValues.ReverseProxy.Tolerations = []model.Toleration{}
+
+	manifests, err := model.HelmTemplateFromStruct(t, model.ReverseProxyHelmChart, helmValues)
+	assert.NoError(t, err, "error seen while testing empty tolerations with reverse proxy helm chart")
+
+	deploymentList := manifests.OfType(&appsv1.Deployment{})
+	assert.Len(t, deploymentList, 1, fmt.Sprintf("number of deployments should be 1, not %d", len(deploymentList)))
+
+	deployment := deploymentList[0].(*appsv1.Deployment)
+	tolerations := deployment.Spec.Template.Spec.Tolerations
+	assert.Nil(t, tolerations, "tolerations should not be present when empty")
+}
+
+// TestReverseProxyTolerationsWithNodeSelector checks if both tolerations and nodeSelector work together
+func TestReverseProxyTolerationsWithNodeSelector(t *testing.T) {
+	t.Parallel()
+
+	dummyToleration := model.Toleration{
+		Key:      "dedicated",
+		Operator: "Equal",
+		Value:    "reverse-proxy",
+		Effect:   "NoSchedule",
+	}
+	nodeSelectorLabels := map[string]string{
+		"workload-type": "reverse-proxy",
+	}
+	helmValues := model.DefaultNeo4jReverseProxyValues
+	helmValues.ReverseProxy.ServiceName = "neo4j-service"
+	helmValues.ReverseProxy.Tolerations = []model.Toleration{dummyToleration}
+	helmValues.ReverseProxy.NodeSelector = nodeSelectorLabels
+
+	manifests, err := model.HelmTemplateFromStruct(t, model.ReverseProxyHelmChart, helmValues)
+	assert.NoError(t, err, "error seen while testing tolerations with nodeSelector on reverse proxy helm chart")
+
+	deploymentList := manifests.OfType(&appsv1.Deployment{})
+	assert.Len(t, deploymentList, 1, fmt.Sprintf("number of deployments should be 1, not %d", len(deploymentList)))
+
+	deployment := deploymentList[0].(*appsv1.Deployment)
+	tolerations := deployment.Spec.Template.Spec.Tolerations
+	assert.Len(t, tolerations, 1, "should have exactly one toleration")
+
+	nodeSelector := deployment.Spec.Template.Spec.NodeSelector
+	assert.NotNil(t, nodeSelector, "nodeSelector should be present")
+	assert.Equal(t, nodeSelectorLabels, nodeSelector, "nodeSelector labels should match")
+}
+
 // TestReverseProxyImagePullSecrets tests that imagePullSecrets are correctly set in the reverse proxy deployment
 func TestReverseProxyImagePullSecrets(t *testing.T) {
 	t.Parallel()

--- a/neo4j-reverse-proxy/templates/_helpers.tpl
+++ b/neo4j-reverse-proxy/templates/_helpers.tpl
@@ -64,3 +64,9 @@ host: {{ $.Values.reverseProxy.ingress.host | quote }}
 nodeSelector: {{ .Values.reverseProxy.nodeSelector | toYaml | nindent 2 }}
 {{- end }}
 {{- end }}
+
+{{- define "neo4j.tolerations" -}}
+{{- if and (not (kindIs "invalid" .Values.reverseProxy.tolerations)) (not (empty .Values.reverseProxy.tolerations)) }}
+tolerations: {{ .Values.reverseProxy.tolerations | toYaml | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/neo4j-reverse-proxy/templates/reverseProxyServer.yaml
+++ b/neo4j-reverse-proxy/templates/reverseProxyServer.yaml
@@ -20,6 +20,7 @@ spec:
     spec:
       securityContext: {{ toYaml .Values.reverseProxy.podSecurityContext | nindent 8 }}
       {{- include "neo4j.nodeSelector" . | nindent 6 }}
+      {{- include "neo4j.tolerations" . | nindent 6 }}
       {{- if .Values.reverseProxy.imagePullSecrets }}
       imagePullSecrets:
       {{- range .Values.reverseProxy.imagePullSecrets }}

--- a/neo4j-reverse-proxy/values.yaml
+++ b/neo4j-reverse-proxy/values.yaml
@@ -53,6 +53,13 @@ reverseProxy:
   #  label1: "value1"
   #  label2: "value2"
 
+  # Tolerations for pod scheduling on tainted nodes
+  tolerations: []
+#    - key: "key1"
+#      operator: "Equal"
+#      value: "value1"
+#      effect: "NoSchedule"
+
   # This assumes ingress-nginx controller or haproxy-ingress-controller is already installed in your kubernetes cluster.
   # You can install ingress-nginx by following instructions on this link https://github.com/kubernetes/ingress-nginx/blob/main/docs/deploy/index.md#quick-start
   # You can install haproxy-ingress by following instructions on this link https://haproxy-ingress.github.io/docs/getting-started/

--- a/neo4j/templates/delete-loadbalancer-hook.yaml
+++ b/neo4j/templates/delete-loadbalancer-hook.yaml
@@ -32,6 +32,7 @@ spec:
     spec:
       serviceAccountName: "{{ include "neo4j.fullname" . }}-cleanup"
       {{- include "neo4j.imagePullSecrets" .Values.image.imagePullSecrets | indent 6 }}
+      {{- include "neo4j.tolerations" .Values.podSpec.tolerations | indent 6 }}
       containers:
         - name: kubectl
           image: "{{ include "cleanup.image" . }}"

--- a/neo4j/templates/neo4j-operations.yaml
+++ b/neo4j/templates/neo4j-operations.yaml
@@ -26,6 +26,7 @@ spec:
       securityContext: {{ toYaml . | nindent 8 }}
       {{- end }}
       {{- include "neo4j.imagePullSecrets" .Values.image.imagePullSecrets | indent 6 }}
+      {{- include "neo4j.tolerations" .Values.podSpec.tolerations | indent 6 }}
       containers:
         - name: {{ include "neo4j.fullname" . }}-operations
           image: {{ $.Values.neo4j.operations.image }}


### PR DESCRIPTION
## Summary

- Add tolerations support to the neo4j-reverse-proxy Deployment chart (values, helper, template)
- Propagate existing `podSpec.tolerations` to the operations Job and pre-delete cleanup Job in the neo4j chart
- Add Go model field and unit tests for reverse proxy tolerations

## Motivation

The neo4j StatefulSet and neo4j-admin CronJob already support tolerations, but the reverse proxy Deployment and the operations/cleanup Jobs did not. This meant pods for those workloads could not be scheduled on tainted nodes, which is a common pattern for dedicated node pools.

## Backwards compatibility

All new fields default to empty (`[]`). Existing deployments are unaffected on upgrade, no tolerations are rendered unless explicitly configured.

Part of HELM-16