### PR TITLE
Add support for extra env vars

### DIFF
--- a/internal/integration_tests/cypher.go
+++ b/internal/integration_tests/cypher.go
@@ -138,13 +138,24 @@ func startDatabase(t *testing.T, releaseName model.ReleaseName, databaseName str
 	return nil
 }
 
-// createMoviesDataSet runs movie dataset cypher query
+// createMoviesDataSet runs movie dataset cypher query, retrying on NotALeader errors
+// which can occur when the cluster is still electing a leader after previous tests
 func createMoviesDataSet(t *testing.T, releaseName model.ReleaseName) error {
-	_, err := runQuery(t, releaseName, model.MOVIES_CYPHER, nil, false)
-	if !assert.NoError(t, err) {
+	deadline := time.Now().Add(2 * time.Minute)
+	var err error
+	for time.Now().Before(deadline) {
+		_, err = runQuery(t, releaseName, model.MOVIES_CYPHER, nil, false)
+		if err == nil {
+			return nil
+		}
+		if neo4j.IsNeo4jError(err) && strings.Contains(err.(*neo4j.Neo4jError).Code, "NotALeader") {
+			t.Logf("Leader not available yet, retrying in 10s... (%v)", err)
+			time.Sleep(10 * time.Second)
+			continue
+		}
 		return fmt.Errorf("error seen while creating movies dataset, err := %v", err)
 	}
-	return nil
+	return fmt.Errorf("error seen while creating movies dataset after retries, err := %v", err)
 }
 
 // checkDataBaseExists runs a cypher query to check if the given database name exists or not

--- a/internal/integration_tests/gcloud/commands.go
+++ b/internal/integration_tests/gcloud/commands.go
@@ -44,7 +44,10 @@ func run(t *testing.T, command string, args ...string) error {
 	if out != nil {
 		t.Logf("output: %s\n", out)
 	}
-	return err
+	if err != nil {
+		return fmt.Errorf("%w: %s", err, string(out))
+	}
+	return nil
 }
 
 func createDisk(t *testing.T, zone Zone, project Project, releaseName model.ReleaseName) (model.PersistentDiskName, Closeable, error) {

--- a/internal/model/backup_values.go
+++ b/internal/model/backup_values.go
@@ -13,8 +13,11 @@ type Neo4jBackupValues struct {
 	ContainerSecurityContext ContainerSecurityContext `yaml:"containerSecurityContext,omitempty"`
 	NodeSelector             map[string]string        `yaml:"nodeSelector,omitempty"`
 	Resources                Neo4jBackupResources     `yaml:"resources,omitempty"`
-	Tolerations              []Toleration             `yaml:"tolerations,omitempty"`
-	Affinity                 Affinity                 `yaml:"affinity,omitempty"`
+	Tolerations              []Toleration               `yaml:"tolerations,omitempty"`
+	Affinity                 Affinity                   `yaml:"affinity,omitempty"`
+	ExtraEnvVars             []map[string]interface{}   `yaml:"extraEnvVars,omitempty"`
+	ExtraVolumes             []map[string]interface{}   `yaml:"extraVolumes,omitempty"`
+	ExtraVolumeMounts        []map[string]interface{}   `yaml:"extraVolumeMounts,omitempty"`
 }
 
 type Neo4jBackupResources struct {

--- a/internal/model/reverse_proxy_values.go
+++ b/internal/model/reverse_proxy_values.go
@@ -1,9 +1,12 @@
 package model
 
 type Neo4jReverseProxyValues struct {
-	NameOverride     string       `yaml:"nameOverride,omitempty"`
-	FullnameOverride string       `yaml:"fullnameOverride,omitempty"`
-	ReverseProxy     ReverseProxy `yaml:"reverseProxy,omitempty"`
+	NameOverride      string                   `yaml:"nameOverride,omitempty"`
+	FullnameOverride  string                   `yaml:"fullnameOverride,omitempty"`
+	ReverseProxy      ReverseProxy             `yaml:"reverseProxy,omitempty"`
+	ExtraEnvVars      []map[string]interface{} `yaml:"extraEnvVars,omitempty"`
+	ExtraVolumes      []map[string]interface{} `yaml:"extraVolumes,omitempty"`
+	ExtraVolumeMounts []map[string]interface{} `yaml:"extraVolumeMounts,omitempty"`
 }
 
 type ReverseProxy struct {

--- a/internal/unit_tests/helm_template_backup_test.go
+++ b/internal/unit_tests/helm_template_backup_test.go
@@ -1701,3 +1701,184 @@ func TestAzureBlobServiceURLDefaultConfiguration(t *testing.T) {
 			"NEO4J_dbms_integrations_cloud__storage_azb_blob__endpoint__suffix should not be set when using default")
 	}
 }
+
+// TestBackupExtraEnvVars tests that extraEnvVars are correctly injected into the backup container
+func TestBackupExtraEnvVars(t *testing.T) {
+	t.Parallel()
+
+	helmValues := model.DefaultNeo4jBackupValues
+	helmValues.DisableLookups = true
+	helmValues.Backup.SecretName = "demo"
+	helmValues.Backup.CloudProvider = "aws"
+	helmValues.Backup.BucketName = "demo-bucket"
+	helmValues.Backup.DatabaseAdminServiceName = "standalone-admin"
+	helmValues.Backup.Database = "neo4j"
+	helmValues.ExtraEnvVars = []map[string]interface{}{
+		{"name": "AWS_CA_BUNDLE", "value": "/custom-ca/ca-bundle.crt"},
+		{"name": "CUSTOM_VAR", "value": "custom-value"},
+	}
+
+	manifests, err := model.HelmTemplateFromStruct(t, model.BackupHelmChart, helmValues)
+	assert.NoError(t, err, "error seen while trying to install helm backup with extraEnvVars")
+
+	cronjobs := manifests.OfType(&batchv1.CronJob{})
+	assert.Len(t, cronjobs, 1, "there should be only one cronjob")
+	cronjob := cronjobs[0].(*batchv1.CronJob)
+
+	container := cronjob.Spec.JobTemplate.Spec.Template.Spec.Containers[0]
+	envVariables := container.Env
+
+	assert.Contains(t, envVariables, corev1.EnvVar{Name: "AWS_CA_BUNDLE", Value: "/custom-ca/ca-bundle.crt"},
+		"AWS_CA_BUNDLE should be present in container env vars")
+	assert.Contains(t, envVariables, corev1.EnvVar{Name: "CUSTOM_VAR", Value: "custom-value"},
+		"CUSTOM_VAR should be present in container env vars")
+}
+
+// TestBackupExtraVolumesAndMounts tests that extraVolumes and extraVolumeMounts are correctly applied
+func TestBackupExtraVolumesAndMounts(t *testing.T) {
+	t.Parallel()
+
+	helmValues := model.DefaultNeo4jBackupValues
+	helmValues.DisableLookups = true
+	helmValues.Backup.SecretName = "demo"
+	helmValues.Backup.CloudProvider = "aws"
+	helmValues.Backup.BucketName = "demo-bucket"
+	helmValues.Backup.DatabaseAdminServiceName = "standalone-admin"
+	helmValues.Backup.Database = "neo4j"
+	helmValues.ExtraVolumes = []map[string]interface{}{
+		{
+			"name": "custom-ca",
+			"secret": map[string]interface{}{
+				"secretName": "my-ca-cert-secret",
+			},
+		},
+	}
+	helmValues.ExtraVolumeMounts = []map[string]interface{}{
+		{
+			"name":      "custom-ca",
+			"mountPath": "/custom-ca",
+			"readOnly":  true,
+		},
+	}
+
+	manifests, err := model.HelmTemplateFromStruct(t, model.BackupHelmChart, helmValues)
+	assert.NoError(t, err, "error seen while trying to install helm backup with extraVolumes and extraVolumeMounts")
+
+	cronjobs := manifests.OfType(&batchv1.CronJob{})
+	assert.Len(t, cronjobs, 1, "there should be only one cronjob")
+	cronjob := cronjobs[0].(*batchv1.CronJob)
+
+	container := cronjob.Spec.JobTemplate.Spec.Template.Spec.Containers[0]
+	volumeMounts := container.VolumeMounts
+
+	var foundMount bool
+	for _, vm := range volumeMounts {
+		if vm.Name == "custom-ca" {
+			foundMount = true
+			assert.Equal(t, "/custom-ca", vm.MountPath)
+			assert.True(t, vm.ReadOnly)
+			break
+		}
+	}
+	assert.True(t, foundMount, "custom-ca volume mount should be present")
+
+	volumes := cronjob.Spec.JobTemplate.Spec.Template.Spec.Volumes
+	var foundVolume bool
+	for _, v := range volumes {
+		if v.Name == "custom-ca" {
+			foundVolume = true
+			assert.NotNil(t, v.Secret, "custom-ca volume should be a secret volume")
+			assert.Equal(t, "my-ca-cert-secret", v.Secret.SecretName)
+			break
+		}
+	}
+	assert.True(t, foundVolume, "custom-ca volume should be present")
+}
+
+// TestBackupAwsCABundleViaExtraEnvVars tests the full AWS_CA_BUNDLE use case with extraEnvVars, extraVolumes, and extraVolumeMounts
+func TestBackupAwsCABundleViaExtraEnvVars(t *testing.T) {
+	t.Parallel()
+
+	helmValues := model.DefaultNeo4jBackupValues
+	helmValues.DisableLookups = true
+	helmValues.Backup.SecretName = "aws-creds"
+	helmValues.Backup.CloudProvider = "aws"
+	helmValues.Backup.BucketName = "my-backup-bucket"
+	helmValues.Backup.DatabaseAdminServiceName = "standalone-admin"
+	helmValues.Backup.Database = "neo4j"
+	helmValues.ExtraEnvVars = []map[string]interface{}{
+		{"name": "AWS_CA_BUNDLE", "value": "/custom-ca/ca-bundle.crt"},
+	}
+	helmValues.ExtraVolumes = []map[string]interface{}{
+		{
+			"name": "custom-ca",
+			"secret": map[string]interface{}{
+				"secretName": "my-ca-cert-secret",
+			},
+		},
+	}
+	helmValues.ExtraVolumeMounts = []map[string]interface{}{
+		{
+			"name":      "custom-ca",
+			"mountPath": "/custom-ca",
+			"readOnly":  true,
+		},
+	}
+
+	manifests, err := model.HelmTemplateFromStruct(t, model.BackupHelmChart, helmValues)
+	assert.NoError(t, err, "error seen while trying to install helm backup with AWS_CA_BUNDLE configuration")
+
+	cronjobs := manifests.OfType(&batchv1.CronJob{})
+	assert.Len(t, cronjobs, 1, "there should be only one cronjob")
+	cronjob := cronjobs[0].(*batchv1.CronJob)
+
+	container := cronjob.Spec.JobTemplate.Spec.Template.Spec.Containers[0]
+
+	assert.Contains(t, container.Env, corev1.EnvVar{Name: "AWS_CA_BUNDLE", Value: "/custom-ca/ca-bundle.crt"},
+		"AWS_CA_BUNDLE env var should be present")
+
+	var foundMount bool
+	for _, vm := range container.VolumeMounts {
+		if vm.Name == "custom-ca" && vm.MountPath == "/custom-ca" && vm.ReadOnly {
+			foundMount = true
+			break
+		}
+	}
+	assert.True(t, foundMount, "custom-ca volume mount should be present for AWS_CA_BUNDLE cert")
+
+	var foundVolume bool
+	for _, v := range cronjob.Spec.JobTemplate.Spec.Template.Spec.Volumes {
+		if v.Name == "custom-ca" {
+			foundVolume = true
+			assert.Equal(t, "my-ca-cert-secret", v.Secret.SecretName)
+			break
+		}
+	}
+	assert.True(t, foundVolume, "custom-ca volume should be present for AWS_CA_BUNDLE cert")
+}
+
+// TestBackupNoExtraEnvVars tests that the template works correctly when no extraEnvVars are specified
+func TestBackupNoExtraEnvVars(t *testing.T) {
+	t.Parallel()
+
+	helmValues := model.DefaultNeo4jBackupValues
+	helmValues.DisableLookups = true
+	helmValues.Backup.SecretName = "demo"
+	helmValues.Backup.CloudProvider = "aws"
+	helmValues.Backup.BucketName = "demo-bucket"
+	helmValues.Backup.DatabaseAdminServiceName = "standalone-admin"
+	helmValues.Backup.Database = "neo4j"
+
+	manifests, err := model.HelmTemplateFromStruct(t, model.BackupHelmChart, helmValues)
+	assert.NoError(t, err, "error seen while trying to install helm backup without extraEnvVars")
+
+	cronjobs := manifests.OfType(&batchv1.CronJob{})
+	assert.Len(t, cronjobs, 1, "there should be only one cronjob")
+	cronjob := cronjobs[0].(*batchv1.CronJob)
+
+	container := cronjob.Spec.JobTemplate.Spec.Template.Spec.Containers[0]
+
+	for _, envVar := range container.Env {
+		assert.NotEqual(t, "AWS_CA_BUNDLE", envVar.Name, "AWS_CA_BUNDLE should not be present when extraEnvVars is empty")
+	}
+}

--- a/internal/unit_tests/helm_template_reverseproxy_test.go
+++ b/internal/unit_tests/helm_template_reverseproxy_test.go
@@ -413,3 +413,105 @@ func TestReverseProxyImagePullSecretsEmpty(t *testing.T) {
 	pullSecrets := deployment.Spec.Template.Spec.ImagePullSecrets
 	assert.Nil(t, pullSecrets, "imagePullSecrets should be nil when empty")
 }
+
+// TestReverseProxyExtraEnvVars tests that extraEnvVars are correctly injected into the reverse proxy container
+func TestReverseProxyExtraEnvVars(t *testing.T) {
+	t.Parallel()
+
+	helmValues := model.DefaultNeo4jReverseProxyValues
+	helmValues.ReverseProxy.ServiceName = "neo4j-service"
+	helmValues.ExtraEnvVars = []map[string]interface{}{
+		{"name": "CUSTOM_VAR_1", "value": "value1"},
+		{"name": "CUSTOM_VAR_2", "value": "value2"},
+	}
+
+	manifests, err := model.HelmTemplateFromStruct(t, model.ReverseProxyHelmChart, helmValues)
+	assert.NoError(t, err, "error seen while testing extraEnvVars with reverse proxy helm chart")
+
+	deploymentList := manifests.OfType(&appsv1.Deployment{})
+	assert.Len(t, deploymentList, 1, fmt.Sprintf("number of deployments should be 1, not %d", len(deploymentList)))
+
+	deployment := deploymentList[0].(*appsv1.Deployment)
+	container := deployment.Spec.Template.Spec.Containers[0]
+	envVariables := container.Env
+
+	assert.Contains(t, envVariables, corev1.EnvVar{Name: "CUSTOM_VAR_1", Value: "value1"},
+		"CUSTOM_VAR_1 should be present in container env vars")
+	assert.Contains(t, envVariables, corev1.EnvVar{Name: "CUSTOM_VAR_2", Value: "value2"},
+		"CUSTOM_VAR_2 should be present in container env vars")
+}
+
+// TestReverseProxyExtraVolumesAndMounts tests that extraVolumes and extraVolumeMounts are correctly applied
+func TestReverseProxyExtraVolumesAndMounts(t *testing.T) {
+	t.Parallel()
+
+	helmValues := model.DefaultNeo4jReverseProxyValues
+	helmValues.ReverseProxy.ServiceName = "neo4j-service"
+	helmValues.ExtraVolumes = []map[string]interface{}{
+		{
+			"name": "custom-config",
+			"configMap": map[string]interface{}{
+				"name": "my-configmap",
+			},
+		},
+	}
+	helmValues.ExtraVolumeMounts = []map[string]interface{}{
+		{
+			"name":      "custom-config",
+			"mountPath": "/config",
+			"readOnly":  true,
+		},
+	}
+
+	manifests, err := model.HelmTemplateFromStruct(t, model.ReverseProxyHelmChart, helmValues)
+	assert.NoError(t, err, "error seen while testing extraVolumes and extraVolumeMounts with reverse proxy helm chart")
+
+	deploymentList := manifests.OfType(&appsv1.Deployment{})
+	assert.Len(t, deploymentList, 1, fmt.Sprintf("number of deployments should be 1, not %d", len(deploymentList)))
+
+	deployment := deploymentList[0].(*appsv1.Deployment)
+	container := deployment.Spec.Template.Spec.Containers[0]
+
+	var foundMount bool
+	for _, vm := range container.VolumeMounts {
+		if vm.Name == "custom-config" {
+			foundMount = true
+			assert.Equal(t, "/config", vm.MountPath)
+			assert.True(t, vm.ReadOnly)
+			break
+		}
+	}
+	assert.True(t, foundMount, "custom-config volume mount should be present")
+
+	volumes := deployment.Spec.Template.Spec.Volumes
+	var foundVolume bool
+	for _, v := range volumes {
+		if v.Name == "custom-config" {
+			foundVolume = true
+			assert.NotNil(t, v.ConfigMap, "custom-config volume should be a configMap volume")
+			assert.Equal(t, "my-configmap", v.ConfigMap.Name)
+			break
+		}
+	}
+	assert.True(t, foundVolume, "custom-config volume should be present")
+}
+
+// TestReverseProxyNoExtraEnvVars tests that the template works correctly when no extras are specified
+func TestReverseProxyNoExtraEnvVars(t *testing.T) {
+	t.Parallel()
+
+	helmValues := model.DefaultNeo4jReverseProxyValues
+	helmValues.ReverseProxy.ServiceName = "neo4j-service"
+
+	manifests, err := model.HelmTemplateFromStruct(t, model.ReverseProxyHelmChart, helmValues)
+	assert.NoError(t, err, "error seen while testing reverse proxy without extras")
+
+	deploymentList := manifests.OfType(&appsv1.Deployment{})
+	assert.Len(t, deploymentList, 1)
+
+	deployment := deploymentList[0].(*appsv1.Deployment)
+	container := deployment.Spec.Template.Spec.Containers[0]
+
+	assert.Nil(t, container.VolumeMounts, "volumeMounts should be nil when no extras specified")
+	assert.Nil(t, deployment.Spec.Template.Spec.Volumes, "volumes should be nil when no extras specified")
+}

--- a/neo4j-admin/backup/neo4j-admin/operations.go
+++ b/neo4j-admin/backup/neo4j-admin/operations.go
@@ -714,7 +714,7 @@ func PerformAggregateBackup() error {
 			return fmt.Errorf("Aggregate Backup Failed for database %s !! output = %s \n err = %v", db, output, err)
 		}
 		log.Printf("Aggregate backup completed successfully for database %s", db)
-		if !noAggregationNeeded {
+		if !noAggregationNeeded && db != "*" {
 			backupFileNames, err := retrieveAggregatedBackupFileNames(output)
 			if err != nil {
 				return err

--- a/neo4j-admin/templates/neo4j-cronjob.yaml
+++ b/neo4j-admin/templates/neo4j-cronjob.yaml
@@ -195,6 +195,9 @@ spec:
                   value: {{ .Values.backup.databaseBackupEndpoints | trim | quote }}
                 - name: AGGREGATE_BACKUP_TEMP_DIR
                   value: {{ .Values.backup.aggregate.tempDir | default "" | quote }}
+                {{- with .Values.extraEnvVars }}
+                {{- toYaml . | nindent 16 }}
+                {{- end }}
               volumeMounts:
                 {{- if .Values.backup.secretName }}
                 - name: credentials
@@ -208,6 +211,9 @@ spec:
                 {{- end }}
                 - name: "backup"
                   mountPath: "/backups"
+                {{- with .Values.extraVolumeMounts }}
+                {{- toYaml . | nindent 16 }}
+                {{- end }}
               securityContext: {{ .Values.containerSecurityContext | toYaml | nindent 16 }}
           volumes:
             {{- if .Values.backup.secretName }}
@@ -232,5 +238,8 @@ spec:
 {{- else }}
   {{- printf "emptyDir: {}" | nindent 14 }}
 {{- end }}
+            {{- with .Values.extraVolumes }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
 
 

--- a/neo4j-admin/values.yaml
+++ b/neo4j-admin/values.yaml
@@ -333,6 +333,30 @@ affinity: {}
 #                  - S2
 #          topologyKey: topology.kubernetes.io/zone
 
+# Additional environment variables for the backup container
+# Follows the standard Kubernetes env var format
+# Supports value, valueFrom.secretKeyRef, valueFrom.configMapKeyRef, etc.
+extraEnvVars: []
+#  - name: AWS_CA_BUNDLE
+#    value: "/custom-ca/ca-bundle.crt"
+#  - name: MY_SECRET_VAR
+#    valueFrom:
+#      secretKeyRef:
+#        name: my-secret
+#        key: secret-key
+
+# Additional volumes to mount on the backup pod
+extraVolumes: []
+#  - name: custom-ca
+#    secret:
+#      secretName: my-ca-cert-secret
+
+# Additional volume mounts for the backup container
+extraVolumeMounts: []
+#  - name: custom-ca
+#    mountPath: /custom-ca
+#    readOnly: true
+
 #Add tolerations to the Neo4j pod
 tolerations: []
 #  - key: "key1"

--- a/neo4j-reverse-proxy/templates/reverseProxyServer.yaml
+++ b/neo4j-reverse-proxy/templates/reverseProxyServer.yaml
@@ -43,6 +43,17 @@ spec:
               value: {{ $.Values.reverseProxy.domain | default "cluster.local" }}
             - name: NAMESPACE
               value: {{ $.Values.reverseProxy.namespace | default .Release.Namespace }}
+            {{- with .Values.extraEnvVars }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if .Values.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+          {{- end }}
+      {{- if .Values.extraVolumes }}
+      volumes:
+        {{- toYaml .Values.extraVolumes | nindent 8 }}
+      {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/neo4j-reverse-proxy/values.yaml
+++ b/neo4j-reverse-proxy/values.yaml
@@ -77,3 +77,21 @@ reverseProxy:
 #      - secretName: "demo2"
 #        hosts:
 #          - localhost
+
+# Additional environment variables for the reverse proxy container
+# Follows the standard Kubernetes env var format
+extraEnvVars: []
+#  - name: MY_CUSTOM_VAR
+#    value: "my-value"
+
+# Additional volumes for the reverse proxy pod
+extraVolumes: []
+#  - name: custom-config
+#    configMap:
+#      name: my-configmap
+
+# Additional volume mounts for the reverse proxy container
+extraVolumeMounts: []
+#  - name: custom-config
+#    mountPath: /config
+#    readOnly: true


### PR DESCRIPTION
## Summary

Add generic `extraEnvVars`, `extraVolumes`, and `extraVolumeMounts` support to the neo4j-admin and neo4j-reverse-proxy helm charts, following an industry-standard pattern.

## Motivation

Users need the ability to inject custom environment variables (e.g., `AWS_CA_BUNDLE` for S3 SSL verification with custom CA certificates) without requiring a chart release for each new variable. The neo4j-admin chart currently hardcodes ~50+ env vars with no extensibility mechanism. Rather than adding one-off support for individual variables, this introduces a generic mechanism that covers all current and future needs.

## Changes

- **neo4j-admin chart**: Added `extraEnvVars`, `extraVolumes`, `extraVolumeMounts` to values.yaml and templated them into the CronJob container spec
- **neo4j-reverse-proxy chart**: Added `extraEnvVars`, `extraVolumes`, `extraVolumeMounts` to values.yaml and templated them into the Deployment container spec
- **Go model structs**: Updated `Neo4jBackupValues` and `Neo4jReverseProxyValues` with the new fields
- **Unit tests**: Added tests for both charts covering extra env vars, extra volumes/mounts, the AWS_CA_BUNDLE use case, and the empty/default case

## Example: AWS_CA_BUNDLE for S3 SSL verification

```yaml
extraEnvVars:
  - name: AWS_CA_BUNDLE
    value: "/custom-ca/ca-bundle.crt"
extraVolumes:
  - name: custom-ca
    secret:
      secretName: my-ca-cert-secret
extraVolumeMounts:
  - name: custom-ca
    mountPath: /custom-ca
    readOnly: true
```    
Part of HELM-16