### PR TITLE
fix: scope neo4j-reverse-proxy template names to avoid collisions 

### DIFF
--- a/neo4j-reverse-proxy/templates/NOTES.txt
+++ b/neo4j-reverse-proxy/templates/NOTES.txt
@@ -1,14 +1,14 @@
 Thank you for installing neo4j-reverse-proxy helm chart
 
 This chart installs the following resources in "{{ .Release.Namespace }}" namespace:
- * Pod = "{{ include "neo4j.fullname" . }}-reverseproxy"
- * ClusterIP service =  "{{ include "neo4j.fullname" . }}-reverseproxy-service"
+ * Pod = "{{ include "neo4j.reverseProxy.fullname" . }}-reverseproxy"
+ * ClusterIP service =  "{{ include "neo4j.reverseProxy.fullname" . }}-reverseproxy-service"
 
 {{- if $.Values.reverseProxy.ingress.enabled }}
-{{- $ingressName := printf "%s-reverseproxy-ingress" (include "neo4j.fullname" .) -}}
+{{- $ingressName := printf "%s-reverseproxy-ingress" (include "neo4j.reverseProxy.fullname" .) -}}
 {{- $hostname := printf "$(kubectl get ingress/%s -n %s -o jsonpath='{.status.loadBalancer.ingress[0].ip}')"  $ingressName .Release.Namespace -}}
 {{- $port := include "neo4j.reverseProxy.port" . }}
- * Ingress = "{{ include "neo4j.fullname" . }}-reverseproxy-ingress"
+ * Ingress = "{{ include "neo4j.reverseProxy.fullname" . }}-reverseproxy-ingress"
 
 You can get the ingress address by executing the below command. (It can take a few seconds for the address to appear)
     {{ printf "kubectl get ingress/%s -n %s -o jsonpath='{.status.loadBalancer.ingress[0].ip}'"  $ingressName .Release.Namespace }}

--- a/neo4j-reverse-proxy/templates/_helpers.tpl
+++ b/neo4j-reverse-proxy/templates/_helpers.tpl
@@ -1,4 +1,4 @@
-{{- define "neo4j.fullname" -}}
+{{- define "neo4j.reverseProxy.fullname" -}}
     {{- if .Values.fullnameOverride -}}
         {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
     {{- else -}}
@@ -15,7 +15,7 @@
     {{- end -}}
 {{- end -}}
 
-{{- define "neo4j.annotations" -}}
+{{- define "neo4j.reverseProxy.annotations" -}}
     {{- if not (empty .) }}
 annotations:
         {{- with . -}}
@@ -41,7 +41,7 @@ tls: {{ toYaml $.Values.reverseProxy.ingress.tls.config | nindent 2 }}
 {{- end -}}
 
 {{- define "neo4j.reverseProxy.ingressName" -}}
-{{- $ingressName := printf "%s-reverseproxy-ingress" (include "neo4j.fullname" .) -}}
+{{- $ingressName := printf "%s-reverseproxy-ingress" (include "neo4j.reverseProxy.fullname" .) -}}
 {{- printf "$(kubectl get ingress/%s -n %s -o jsonpath='{.status.loadBalancer.ingress[0].ip}')"  $ingressName .Release.Namespace -}}
 {{- end -}}
 
@@ -51,7 +51,7 @@ host: {{ $.Values.reverseProxy.ingress.host | quote }}
 {{- end }}
 {{- end -}}
 
-{{- define "neo4j.labels" -}}
+{{- define "neo4j.reverseProxy.labels" -}}
     {{- with . -}}
         {{- range $name, $value := . }}
 {{ $name }}: "{{ $value }}"
@@ -59,13 +59,13 @@ host: {{ $.Values.reverseProxy.ingress.host | quote }}
     {{- end -}}
 {{- end }}
 
-{{- define "neo4j.nodeSelector" -}}
+{{- define "neo4j.reverseProxy.nodeSelector" -}}
 {{- if and (not (kindIs "invalid" .Values.reverseProxy.nodeSelector) ) (not (empty .Values.reverseProxy.nodeSelector) ) }}
 nodeSelector: {{ .Values.reverseProxy.nodeSelector | toYaml | nindent 2 }}
 {{- end }}
 {{- end }}
 
-{{- define "neo4j.tolerations" -}}
+{{- define "neo4j.reverseProxy.tolerations" -}}
 {{- if and (not (kindIs "invalid" .Values.reverseProxy.tolerations)) (not (empty .Values.reverseProxy.tolerations)) }}
 tolerations: {{ .Values.reverseProxy.tolerations | toYaml | nindent 2 }}
 {{- end }}

--- a/neo4j-reverse-proxy/templates/ingress.yaml
+++ b/neo4j-reverse-proxy/templates/ingress.yaml
@@ -3,9 +3,9 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "neo4j.fullname" . }}-reverseproxy-ingress
+  name: {{ include "neo4j.reverseProxy.fullname" . }}-reverseproxy-ingress
   namespace: "{{ .Release.Namespace }}"
-  {{- include "neo4j.annotations" $.Values.reverseProxy.ingress.annotations | indent 2 }}
+  {{- include "neo4j.reverseProxy.annotations" $.Values.reverseProxy.ingress.annotations | indent 2 }}
 spec:
   ingressClassName: "{{ .Values.reverseProxy.ingress.className | default "nginx" }}"
   {{- include "neo4j.ingress.tls" . | indent 2 }}
@@ -15,7 +15,7 @@ spec:
           - pathType: Prefix
             backend:
               service:
-                name: {{ include "neo4j.fullname" . }}-reverseproxy-service
+                name: {{ include "neo4j.reverseProxy.fullname" . }}-reverseproxy-service
                 port:
                   number: {{ include "neo4j.reverseProxy.port" . }}
             path: /

--- a/neo4j-reverse-proxy/templates/reverseProxyServer.yaml
+++ b/neo4j-reverse-proxy/templates/reverseProxyServer.yaml
@@ -2,25 +2,25 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "neo4j.fullname" . }}-reverseproxy-dep
+  name: {{ include "neo4j.reverseProxy.fullname" . }}-reverseproxy-dep
   labels:
-    name: {{ include "neo4j.fullname" . }}-reverseproxy-dep
+    name: {{ include "neo4j.reverseProxy.fullname" . }}-reverseproxy-dep
   namespace: "{{ .Release.Namespace }}"
 spec:
   replicas: 1
   selector:
     matchLabels:
-      name: {{ include "neo4j.fullname" . }}-reverseproxy
+      name: {{ include "neo4j.reverseProxy.fullname" . }}-reverseproxy
   template:
     metadata:
-      name: {{ include "neo4j.fullname" . }}-reverseproxy
+      name: {{ include "neo4j.reverseProxy.fullname" . }}-reverseproxy
       labels:
-        name: {{ include "neo4j.fullname" . }}-reverseproxy
-        {{- include "neo4j.labels" $.Values.reverseProxy.podLabels | indent 8 }}
+        name: {{ include "neo4j.reverseProxy.fullname" . }}-reverseproxy
+        {{- include "neo4j.reverseProxy.labels" $.Values.reverseProxy.podLabels | indent 8 }}
     spec:
       securityContext: {{ toYaml .Values.reverseProxy.podSecurityContext | nindent 8 }}
-      {{- include "neo4j.nodeSelector" . | nindent 6 }}
-      {{- include "neo4j.tolerations" . | nindent 6 }}
+      {{- include "neo4j.reverseProxy.nodeSelector" . | nindent 6 }}
+      {{- include "neo4j.reverseProxy.tolerations" . | nindent 6 }}
       {{- if .Values.reverseProxy.imagePullSecrets }}
       imagePullSecrets:
       {{- range .Values.reverseProxy.imagePullSecrets }}
@@ -28,7 +28,7 @@ spec:
       {{- end }}
       {{- end }}
       containers:
-        - name: {{ include "neo4j.fullname" . }}-reverseproxy
+        - name: {{ include "neo4j.reverseProxy.fullname" . }}-reverseproxy
           image: {{ $.Values.reverseProxy.image }}
           imagePullPolicy: Always
           securityContext: {{ toYaml .Values.reverseProxy.containerSecurityContext | nindent 12 }}
@@ -58,12 +58,12 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "neo4j.fullname" . }}-reverseproxy-service
+  name: {{ include "neo4j.reverseProxy.fullname" . }}-reverseproxy-service
   namespace: "{{ .Release.Namespace }}"
 spec:
   type: ClusterIP
   selector:
-    name: {{ include "neo4j.fullname" . }}-reverseproxy
+    name: {{ include "neo4j.reverseProxy.fullname" . }}-reverseproxy
   ports:
     - protocol: TCP
       port: {{ $port }}


### PR DESCRIPTION
## Fix _helpers.tpl collisions when neo4j and neo4j-reverse-proxy are used together.

When both charts are used as subcharts of a parent chart, Helm's flat template namespace causes
conflicting definitions to override each other, resulting in nil pointer errors.

Renames five template definitions in `neo4j-reverse-proxy` to use a `reverseProxy` scope:
- `neo4j.fullname` → `neo4j.reverseProxy.fullname`
- `neo4j.annotations` → `neo4j.reverseProxy.annotations`
- `neo4j.labels` → `neo4j.reverseProxy.labels`
- `neo4j.nodeSelector` → `neo4j.reverseProxy.nodeSelector`
- `neo4j.tolerations` → `neo4j.reverseProxy.tolerations`

Fixes #516