### PR TITLE
Fix template name collisions

### DIFF
--- a/neo4j-admin/templates/_helpers.tpl
+++ b/neo4j-admin/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "neo4j.fullname" -}}
+{{- define "neo4j.admin.fullname" -}}
     {{- if .Values.fullnameOverride -}}
         {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
     {{- else -}}
@@ -20,7 +20,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/* checkNodeSelectorLabels checks if there is any node in the cluster which has nodeSelector labels */}}
-{{- define "neo4j.checkNodeSelectorLabels" -}}
+{{- define "neo4j.admin.checkNodeSelectorLabels" -}}
     {{- if and (not (empty $.Values.nodeSelector)) (not $.Values.disableLookups) -}}
         {{- $validNodes := 0 -}}
         {{- $numberOfLabelsRequired := len $.Values.nodeSelector -}}
@@ -48,7 +48,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
     {{- end -}}
 {{- end -}}
 
-{{- define "neo4j.tolerations" -}}
+{{- define "neo4j.admin.tolerations" -}}
 {{/* Add tolerations only if .Values.tolerations contains entries */}}
     {{- if . -}}
 tolerations:
@@ -56,14 +56,14 @@ tolerations:
     {{- end -}}
 {{- end -}}
 
-{{- define "neo4j.affinity" -}}
+{{- define "neo4j.admin.affinity" -}}
     {{- if . -}}
 affinity:
 {{ toYaml . | indent 1 }}
     {{- end -}}
 {{- end -}}
 
-{{- define "neo4j.resourcesAndLimits" -}}
+{{- define "neo4j.admin.resourcesAndLimits" -}}
 requests:
   ephemeral-storage: {{ .Values.resources.requests.ephemeralStorage | default "4Gi" }}
 

--- a/neo4j-admin/templates/_labels.tpl
+++ b/neo4j-admin/templates/_labels.tpl
@@ -1,4 +1,4 @@
-{{- define "neo4j.labels" -}}
+{{- define "neo4j.admin.labels" -}}
     {{- with . -}}
         {{- range $name, $value := . }}
 {{ $name }}: "{{ $value }}"
@@ -6,7 +6,7 @@
     {{- end -}}
 {{- end }}
 
-{{- define "neo4j.annotations" -}}
+{{- define "neo4j.admin.annotations" -}}
     {{- with . -}}
         {{- range $name, $value := . }}
 {{ $name }}: "{{ $value }}"
@@ -14,7 +14,7 @@
     {{- end -}}
 {{- end }}
 
-{{- define "neo4j.nodeSelector" -}}
+{{- define "neo4j.admin.nodeSelector" -}}
 {{- if and (not (kindIs "invalid" .Values.nodeSelector) ) (not (empty .Values.nodeSelector) ) }}
 {{ printf "nodeSelector" | indent 10 }}: {{ .Values.nodeSelector | toYaml | nindent 12 }}
 {{- end }}

--- a/neo4j-admin/templates/_validation.tpl
+++ b/neo4j-admin/templates/_validation.tpl
@@ -1,8 +1,8 @@
-{{- define "neo4j.backup.checkIfSecretExistsOrNot" -}}
+{{- define "neo4j.admin.backup.checkIfSecretExistsOrNot" -}}
     {{- if (.Values.backup.secretName | trim) -}}
         {{- if (not .Values.disableLookups) -}}
 
-            {{- include "neo4j.backup.checkIfSecretKeyNameExistsOrNot" . -}}
+            {{- include "neo4j.admin.backup.checkIfSecretKeyNameExistsOrNot" . -}}
             {{- $secret := (lookup "v1" "Secret" .Release.Namespace .Values.backup.secretName) }}
             {{- $secretExists := $secret | all }}
 
@@ -15,7 +15,7 @@
     {{- end -}}
 {{- end -}}
 
-{{- define "neo4j.backup.checkAzureStorageAccountName" -}}
+{{- define "neo4j.admin.backup.checkAzureStorageAccountName" -}}
     {{- if eq .Values.backup.cloudProvider "azure" }}
         {{- if and (or (empty .Values.backup.secretName) (empty .Values.backup.secretKeyName)) (empty .Values.backup.azureStorageAccountName) -}}
             {{ fail (printf "Both secretName|secretKeyName and azureStorageAccountName key cannot be empty. Please set one of them via --set backup.secretName or --set backup.azureStorageAccountName") }}
@@ -28,7 +28,7 @@
 {{- end -}}
 
 {{/*check for secretKeyName existence only when secretName is provided*/}}
-{{- define "neo4j.backup.checkIfSecretKeyNameExistsOrNot" -}}
+{{- define "neo4j.admin.backup.checkIfSecretKeyNameExistsOrNot" -}}
    {{- if .Values.backup.secretName -}}
     {{- if kindIs "invalid" .Values.backup.secretKeyName -}}
         {{- fail (printf "Missing secretKeyName !!") -}}
@@ -40,14 +40,14 @@
 {{- end -}}
 
 {{/* checks if serviceAccountName is provided or not  when secretName is missing */}}
-{{- define "neo4j.backup.checkServiceAccountName" -}}
+{{- define "neo4j.admin.backup.checkServiceAccountName" -}}
     {{- if and (empty .Values.serviceAccountName) (empty .Values.backup.secretName) (not (empty .Values.backup.cloudProvider)) -}}
         {{ fail (printf "Please provide either secretName or serviceAccountName. Both cannot be empty. Please set only one of them via --set backup.secretName or --set serviceAccountName") }}
     {{- end -}}
 {{- end -}}
 
 {{/* checks if serviceAccountName is provided or not  when secretName is missing */}}
-{{- define "neo4j.backup.checkBucketName" -}}
+{{- define "neo4j.admin.backup.checkBucketName" -}}
     {{- if or (kindIs "invalid" .Values.backup.aggregate) (not .Values.backup.aggregate.enabled) -}}
         {{- if .Values.backup.cloudProvider -}}
             {{- if empty .Values.backup.bucketName -}}
@@ -57,7 +57,7 @@
     {{- end -}}
 {{- end -}}
 
-{{- define "neo4j.backup.checkDatabaseIPAndServiceName" -}}
+{{- define "neo4j.admin.backup.checkDatabaseIPAndServiceName" -}}
 
     {{- if or (kindIs "invalid" .Values.backup.aggregate) (not .Values.backup.aggregate.enabled) -}}
         {{- if and (kindIs "invalid" .Values.backup.databaseAdminServiceName) (kindIs "invalid" .Values.backup.databaseAdminServiceIP) (kindIs "invalid" .Values.backup.databaseBackupEndpoints) -}}
@@ -76,7 +76,7 @@
 {{- end -}}
 
 {{/* Validate and set default timeout for consistency check */}}
-{{- define "neo4j.backup.validateAndSetTimeout" -}}
+{{- define "neo4j.admin.backup.validateAndSetTimeout" -}}
     {{- $timeout := .Values.consistencyCheck.timeout | default "" -}}
     {{- if $timeout -}}
         {{- /* Validate timeout format using regex for Go duration format */ -}}

--- a/neo4j-admin/templates/neo4j-cronjob.yaml
+++ b/neo4j-admin/templates/neo4j-cronjob.yaml
@@ -1,25 +1,25 @@
-{{- template "neo4j.backup.checkDatabaseIPAndServiceName" . -}}
-{{- template "neo4j.backup.checkAzureStorageAccountName" . -}}
-{{- template "neo4j.backup.checkIfSecretExistsOrNot" . -}}
-{{- template "neo4j.backup.checkBucketName" . -}}
-{{- template "neo4j.backup.checkServiceAccountName" . -}}
-{{- template "neo4j.checkNodeSelectorLabels" . -}}
+{{- template "neo4j.admin.backup.checkDatabaseIPAndServiceName" . -}}
+{{- template "neo4j.admin.backup.checkAzureStorageAccountName" . -}}
+{{- template "neo4j.admin.backup.checkIfSecretExistsOrNot" . -}}
+{{- template "neo4j.admin.backup.checkBucketName" . -}}
+{{- template "neo4j.admin.backup.checkServiceAccountName" . -}}
+{{- template "neo4j.admin.checkNodeSelectorLabels" . -}}
 {{- if and .Values.backup.s3CASecretName (not .Values.backup.s3CASecretKey) }}
 {{- fail "If backup.s3CASecretName is specified, backup.s3CASecretKey must also be specified" }}
 {{- end }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: "{{ include "neo4j.fullname" . }}"
+  name: "{{ include "neo4j.admin.fullname" . }}"
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/instance: {{ include "neo4j.fullname" . | quote }}
+    app.kubernetes.io/instance: {{ include "neo4j.admin.fullname" . | quote }}
     {{- if and (not (kindIs "invalid" .Values.backup.aggregate)) .Values.backup.aggregate.enabled }}
     app.kubernetes.io/component: aggregate-backup
     {{- else }}
     app.kubernetes.io/component: backup
     {{- end }}
-    {{- include "neo4j.labels" $.Values.neo4j.labels | indent 4 }}
+    {{- include "neo4j.admin.labels" $.Values.neo4j.labels | indent 4 }}
 spec:
   schedule: {{ $.Values.neo4j.jobSchedule | default "* * * * *" | quote }}
   concurrencyPolicy: Forbid
@@ -31,9 +31,9 @@ spec:
       template:
         metadata:
           annotations:
-            {{- include "neo4j.annotations" $.Values.neo4j.podAnnotations | indent 12 }}
+            {{- include "neo4j.admin.annotations" $.Values.neo4j.podAnnotations | indent 12 }}
           labels:
-            {{- include "neo4j.labels" $.Values.neo4j.podLabels | indent 12 }}
+            {{- include "neo4j.admin.labels" $.Values.neo4j.podLabels | indent 12 }}
         spec:
           {{- if .Values.serviceAccountName }}
           serviceAccountName: {{ .Values.serviceAccountName }}
@@ -48,16 +48,16 @@ spec:
           {{- end }}
           {{- end }}
           securityContext: {{ .Values.securityContext | toYaml  | nindent 12 }}
-          {{- include "neo4j.tolerations" .Values.tolerations | nindent 10 }}
-          {{- include "neo4j.affinity" .Values.affinity| nindent 10 }}
-          {{- include "neo4j.nodeSelector" . }}
+          {{- include "neo4j.admin.tolerations" .Values.tolerations | nindent 10 }}
+          {{- include "neo4j.admin.affinity" .Values.affinity| nindent 10 }}
+          {{- include "neo4j.admin.nodeSelector" . }}
           containers:
             - name: graph-backup
               {{- $registry := .Values.neo4j.registry | default "" }}
               {{- $image_prefix := ternary (printf "%s/" $registry) "" (ne $registry "") }}
               image: {{ $image_prefix }}{{ .Values.neo4j.image }}:{{ .Values.neo4j.imageTag }}
               imagePullPolicy: Always
-              resources: {{- include "neo4j.resourcesAndLimits" . | nindent 16 }}
+              resources: {{- include "neo4j.admin.resourcesAndLimits" . | nindent 16 }}
               env:
                 - name: DATABASE_SERVICE_NAME
                   value: {{ .Values.backup.databaseAdminServiceName  | trim | quote }}
@@ -178,7 +178,7 @@ spec:
                 - name: CONSISTENCY_CHECK_TEMP_DIR
                   value: {{ .Values.consistencyCheck.tempDir | default "" | quote }}
                 - name: CONSISTENCY_CHECK_TIMEOUT
-                  value: {{ include "neo4j.backup.validateAndSetTimeout" . | quote }}
+                  value: {{ include "neo4j.admin.backup.validateAndSetTimeout" . | quote }}
                 - name: AGGREGATE_BACKUP_ENABLED
                   value: {{ .Values.backup.aggregate.enabled | toString | quote | default false }}
                 - name: AGGREGATE_BACKUP_VERBOSE

--- a/neo4j-headless-service/templates/NOTES.txt
+++ b/neo4j-headless-service/templates/NOTES.txt
@@ -1,8 +1,8 @@
-{{- define "neo4j.namespaceParameter" -}}
+{{- define "neo4j.headlessService.namespaceParameter" -}}
 {{ if ne "default" .Release.Namespace }} --namespace "{{.Release.Namespace}}"{{ end }}
 {{- end -}}
 
-{{- define "neo4j.logPassword" -}}
+{{- define "neo4j.headlessService.logPassword" -}}
 {{ if .Values.logInitialPassword }}{{ .Values.neo4j.password }}{{ else }}**********{{ end }}
 {{- end -}}
 
@@ -24,7 +24,7 @@ You have updated {{ .Chart.Name }} in namespace "{{ .Release.Namespace }}".
 
 Once rollout is complete you can connect to your Neo4j cluster using "neo4j://{{ .Release.Name }}-neo4j.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ $boltPort }}". Try:
 
-  $ kubectl run --rm -it{{ template "neo4j.namespaceParameter" . }} --image "{{ template "neo4j.image" . }}" cypher-shell \
-     -- cypher-shell -a "neo4j://{{ template "neo4j.name" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ $boltPort }}"{{ if not $authDisabled | and .Values.neo4j.password |and .Values.logInitialPassword}} -u neo4j -p "{{ template "neo4j.logPassword" . }}"{{ end }}
+  $ kubectl run --rm -it{{ template "neo4j.headlessService.namespaceParameter" . }} --image "{{ template "neo4j.headlessService.image" . }}" cypher-shell \
+     -- cypher-shell -a "neo4j://{{ template "neo4j.headlessService.name" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ $boltPort }}"{{ if not $authDisabled | and .Values.neo4j.password |and .Values.logInitialPassword}} -u neo4j -p "{{ template "neo4j.headlessService.logPassword" . }}"{{ end }}
 
 Graphs are everywhere!

--- a/neo4j-headless-service/templates/_helpers.tpl
+++ b/neo4j-headless-service/templates/_helpers.tpl
@@ -1,4 +1,4 @@
-{{- define "neo4j.name" -}}
+{{- define "neo4j.headlessService.name" -}}
   {{- if eq (len (trim $.Values.neo4j.name)) 0 -}}
     {{- fail (printf "neo4j.name is required") -}}
   {{- else -}}
@@ -6,27 +6,27 @@
   {{- end -}}
 {{- end -}}
 
-{{- define "neo4j.checkPortMapping" -}}
+{{- define "neo4j.headlessService.checkPortMapping" -}}
     {{- $httpPort := .Values.ports.http.port | int | default 7474 -}}
     {{- $httpsPort := .Values.ports.https.port | int | default 7473 -}}
     {{- $boltPort := .Values.ports.bolt.port | int | default 7687 -}}
     {{- $backupPort := .Values.ports.backup.port | int | default 6362 -}}
 
     {{- if and (eq .Values.ports.http.enabled true) (ne $httpPort 7474) -}}
-        {{- include "neo4j.portRemappingFailureMessage" $httpPort -}}
+        {{- include "neo4j.headlessService.portRemappingFailureMessage" $httpPort -}}
     {{- end -}}
     {{- if and (eq .Values.ports.https.enabled true) (ne $httpsPort 7473) -}}
-        {{- include "neo4j.portRemappingFailureMessage" $httpsPort -}}
+        {{- include "neo4j.headlessService.portRemappingFailureMessage" $httpsPort -}}
     {{- end -}}
     {{- if and (eq .Values.ports.bolt.enabled true) (ne $boltPort 7687) -}}
-        {{- include "neo4j.portRemappingFailureMessage" $boltPort -}}
+        {{- include "neo4j.headlessService.portRemappingFailureMessage" $boltPort -}}
     {{- end -}}
     {{- if and (eq .Values.ports.backup.enabled true) (ne $backupPort 6362) -}}
-        {{- include "neo4j.portRemappingFailureMessage" $backupPort -}}
+        {{- include "neo4j.headlessService.portRemappingFailureMessage" $backupPort -}}
     {{- end -}}
 {{- end -}}
 
-{{- define "neo4j.portRemappingFailureMessage" -}}
+{{- define "neo4j.headlessService.portRemappingFailureMessage" -}}
     {{- $message := . | printf "port re-mapping is not allowed in headless service. Please remove custom port %d from values.yaml" -}}
     {{- fail $message -}}
 {{- end -}}

--- a/neo4j-headless-service/templates/_image.tpl
+++ b/neo4j-headless-service/templates/_image.tpl
@@ -1,4 +1,4 @@
-{{- define "neo4j.defaultChartImage" -}}
+{{- define "neo4j.headlessService.defaultChartImage" -}}
 {{- $isEnterprise := required "neo4j.edition must be specified" .Values.neo4j.edition | regexMatch "(?i)enterprise" -}}
  {{- $imageName := "neo4j:" -}}
  {{/* .Chart.AppVersion is set to "-" for headless and loadbalancer service*/}}
@@ -14,9 +14,9 @@
 {{- end -}}
 
 
-{{- define "neo4j.image" -}}
-{{- template "neo4j.checkLicenseAgreement" . -}}
-{{- $image := include "neo4j.defaultChartImage" . -}}
+{{- define "neo4j.headlessService.image" -}}
+{{- template "neo4j.headlessService.checkLicenseAgreement" . -}}
+{{- $image := include "neo4j.headlessService.defaultChartImage" . -}}
 {{/* Allow override if a custom image has been specified */}}
 {{- if .Values.image -}}
   {{- if .Values.image.customImage -}}

--- a/neo4j-headless-service/templates/_licensing.tpl
+++ b/neo4j-headless-service/templates/_licensing.tpl
@@ -1,17 +1,17 @@
-{{- define "neo4j.checkLicenseAgreement" }}
+{{- define "neo4j.headlessService.checkLicenseAgreement" }}
 {{- $isEnterprise := required "neo4j.edition must be specified" .Values.neo4j.edition | regexMatch "(?i)enterprise" -}}
 {{- if $isEnterprise }}
   {{- if not (kindIs "string" .Values.neo4j.acceptLicenseAgreement) | or (not .Values.neo4j.acceptLicenseAgreement) }}
-  {{- include "neo4j.licenseAgreementMessage" .Values.neo4j.acceptLicenseAgreement | fail }}
+  {{- include "neo4j.headlessService.licenseAgreementMessage" .Values.neo4j.acceptLicenseAgreement | fail }}
   {{- else }}
   {{- if and (ne .Values.neo4j.acceptLicenseAgreement "yes") (ne .Values.neo4j.acceptLicenseAgreement "eval") }}
-    {{- include "neo4j.licenseAgreementMessage" .Values.neo4j.acceptLicenseAgreement | fail }}
+    {{- include "neo4j.headlessService.licenseAgreementMessage" .Values.neo4j.acceptLicenseAgreement | fail }}
   {{- end }}
   {{- end }}
 {{- end }}
 {{- end }}
 
-{{- define "neo4j.licenseAgreementMessage" }}
+{{- define "neo4j.headlessService.licenseAgreementMessage" }}
 
 In order to use Neo4j Enterprise Edition you must have a Neo4j license agreement.
 More information is available at: https://neo4j.com/licensing/

--- a/neo4j-headless-service/templates/neo4j-svc.yaml
+++ b/neo4j-headless-service/templates/neo4j-svc.yaml
@@ -1,13 +1,13 @@
 {{- /* In almost all cases the selector should be unspecified and the default selector should be used. */ -}}
-{{- template "neo4j.checkPortMapping" . -}}
+{{- template "neo4j.headlessService.checkPortMapping" . -}}
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ include "neo4j.name" $ }}-headless"
+  name: "{{ include "neo4j.headlessService.name" $ }}-headless"
   namespace: "{{ .Release.Namespace }}"
   labels:
-    helm.neo4j.com/neo4j.name: "{{ template "neo4j.name" $ }}"
-    app: "{{ template "neo4j.name" . }}"
+    helm.neo4j.com/neo4j.name: "{{ template "neo4j.headlessService.name" $ }}"
+    app: "{{ template "neo4j.headlessService.name" . }}"
   {{- with .Values.annotations }}
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}
@@ -46,7 +46,7 @@ spec:
     {{- end }}
 
   selector:
-    app: "{{ template "neo4j.name" . }}"
+    app: "{{ template "neo4j.headlessService.name" . }}"
     {{- with .Values.selector }}
     {{- . | toYaml | nindent 4 }}
     {{- end }}

--- a/neo4j-loadbalancer/templates/NOTES.txt
+++ b/neo4j-loadbalancer/templates/NOTES.txt
@@ -11,6 +11,6 @@ You have updated {{ .Chart.Name }} in namespace "{{ .Release.Namespace }}".
 {{ end -}}
 
 To view the status of your Load Balancer service you can use
-  $ kubectl get service -n {{ .Release.Namespace }} {{ include "neo4j.name" . }}-{{ .Values.serviceName.suffix | default "lb-neo4j" }}
+  $ kubectl get service -n {{ .Release.Namespace }} {{ include "neo4j.loadbalancer.name" . }}-{{ .Values.serviceName.suffix | default "lb-neo4j" }}
 
 Once your Load Balancer has an External-IP assigned you can connect to your Neo4j cluster using "neo4j://<EXTERNAL-IP>:7474".

--- a/neo4j-loadbalancer/templates/_helpers.tpl
+++ b/neo4j-loadbalancer/templates/_helpers.tpl
@@ -1,7 +1,7 @@
-{{- define "neo4j.name" -}}
+{{- define "neo4j.loadbalancer.name" -}}
   {{- required "neo4j.name is required" .Values.neo4j.name }}
 {{- end -}}
 
-{{- define "neo4j.appName" -}}
+{{- define "neo4j.loadbalancer.appName" -}}
   {{- required "neo4j.name is required" .Values.neo4j.name }}
 {{- end -}}

--- a/neo4j-loadbalancer/templates/_labels.tpl
+++ b/neo4j-loadbalancer/templates/_labels.tpl
@@ -1,4 +1,4 @@
-{{- define "neo4j.labels" -}}
+{{- define "neo4j.loadbalancer.labels" -}}
     {{- with .labels -}}
         {{- range $name, $value := . }}
 {{ $name | quote}}: {{ $value | quote }}
@@ -6,7 +6,7 @@
     {{- end -}}
 {{- end }}
 
-{{- define "neo4j.annotations" -}}
+{{- define "neo4j.loadbalancer.annotations" -}}
     {{- with . -}}
         {{- range $name, $value := . }}
 {{ $name | quote }}: {{ $value | quote }}

--- a/neo4j-loadbalancer/templates/_loadbalancer.tpl
+++ b/neo4j-loadbalancer/templates/_loadbalancer.tpl
@@ -1,4 +1,4 @@
-{{- define "neo4j.services.neo4j.defaultSpec" -}}
+{{- define "neo4j.loadbalancer.services.neo4j.defaultSpec" -}}
 ClusterIP:
   sessionAffinity: None
 NodePort:
@@ -10,7 +10,7 @@ LoadBalancer:
 {{- end }}
 
 
-{{- define "neo4j.services.extraSpec" -}}
+{{- define "neo4j.loadbalancer.services.extraSpec" -}}
 {{- if hasKey . "type" }}{{ fail "field 'type' is not supported in Neo4j LoadBalancer Helm Chart service.*.spec" }}{{ end }}
 {{- if hasKey . "selector" }}{{ fail "field 'selector' is not supported in Neo4j LoadBalancer Helm Chart service.*.spec" }}{{ end }}
 {{- if hasKey . "ports" }}{{ fail "field 'ports' is not supported in Neo4j Helm LoadBalancerChart service .*.spec" }}{{ end }}

--- a/neo4j-loadbalancer/templates/neo4j-svc.yaml
+++ b/neo4j-loadbalancer/templates/neo4j-svc.yaml
@@ -1,23 +1,23 @@
-{{- $defaultSpec := include "neo4j.services.neo4j.defaultSpec" . | fromYaml }}
+{{- $defaultSpec := include "neo4j.loadbalancer.services.neo4j.defaultSpec" . | fromYaml }}
 {{- $spec := get $defaultSpec .Values.spec.type | merge .Values.spec  }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ include "neo4j.name" $ }}-{{ .Values.serviceName.suffix | default "lb-neo4j" }}"
+  name: "{{ include "neo4j.loadbalancer.name" $ }}-{{ .Values.serviceName.suffix | default "lb-neo4j" }}"
   namespace: "{{ .Release.Namespace }}"
   labels:
-    helm.neo4j.com/neo4j.name: "{{ template "neo4j.name" $ }}"
-    app: "{{ template "neo4j.name" . }}"
+    helm.neo4j.com/neo4j.name: "{{ template "neo4j.loadbalancer.name" $ }}"
+    app: "{{ template "neo4j.loadbalancer.name" . }}"
     helm.neo4j.com/service: "neo4j"
-    {{- include "neo4j.labels" .Values.neo4j | indent 4 }}
+    {{- include "neo4j.loadbalancer.labels" .Values.neo4j | indent 4 }}
   annotations:
-  {{- include "neo4j.annotations" $.Values.annotations | indent 4 }}
+  {{- include "neo4j.loadbalancer.annotations" $.Values.annotations | indent 4 }}
 spec:
   {{- if $.Values.multiCluster }}
   publishNotReadyAddresses: true
   {{- end }}
   type: "{{ $.Values.spec.type | required "service type must be specified" }}"
-  {{- omit $spec "type" "ports" "selector" | include "neo4j.services.extraSpec"  | nindent 2 }}
+  {{- omit $spec "type" "ports" "selector" | include "neo4j.loadbalancer.services.extraSpec"  | nindent 2 }}
   ports:
     {{- with .Values.ports }}
     {{- if .http.enabled }}
@@ -77,7 +77,7 @@ spec:
       targetPort: 6000
     {{- end }}
   selector:
-    app: "{{ template "neo4j.name" . }}"
+    app: "{{ template "neo4j.loadbalancer.name" . }}"
     {{- with .Values.selector }}
     {{- . | toYaml | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
## Summary

Fixes #341 - Template rendering conflicts when multiple Neo4j Helm charts are used as sibling dependencies (e.g. in ArgoCD deployments).

When `neo4j` and other charts like `neo4j-admin` are listed as dependencies in the same parent chart, Helm merges all templates into a single namespace. Multiple charts defining templates with the same `neo4j.*` name but different implementations causes Helm to resolve to the wrong definition, producing errors like:
```
error calling include: template: my-app/charts/neo4j-admin/templates/_labels.tpl:18:41: executing "neo4j.nodeSelector" at <.Values.nodeSelector>: nil pointer evaluating interface {}.nodeSelector
```

This PR renames all `neo4j.*` template definitions in three sub-charts to use chart-specific prefixes, eliminating collisions:

- **neo4j-admin**: `neo4j.*` -> `neo4j.admin.*` (15 templates across 4 files)
- **neo4j-loadbalancer**: `neo4j.*` -> `neo4j.loadbalancer.*` (6 templates across 5 files)
- **neo4j-headless-service**: `neo4j.*` -> `neo4j.headlessService.*` (9 templates across 5 files)

The `neo4j` chart itself is unchanged. The naming convention follows `fix/reverse-proxy-template-collisions` which already applied the same fix to neo4j-reverse-proxy using `neo4j.reverseProxy.*`.
