### PR TITLE
Independent resource limits

### DIFF
--- a/internal/model/reverse_proxy_values.go
+++ b/internal/model/reverse_proxy_values.go
@@ -10,15 +10,26 @@ type Neo4jReverseProxyValues struct {
 }
 
 type ReverseProxy struct {
-	Image            string            `yaml:"image,omitempty"`
-	ImagePullSecrets []string          `yaml:"imagePullSecrets,omitempty"`
-	ServiceName      string            `yaml:"serviceName,omitempty"`
-	Namespace        string            `yaml:"namespace,omitempty"`
-	Domain           string            `yaml:"domain,omitempty"`
-	Ingress          Ingress           `yaml:"ingress,omitempty"`
-	PodLabels        map[string]string `yaml:"podLabels,omitempty"`
-	NodeSelector     map[string]string `yaml:"nodeSelector,omitempty"`
-	Tolerations      []Toleration      `yaml:"tolerations,omitempty"`
+	Image            string                `yaml:"image,omitempty"`
+	ImagePullSecrets []string              `yaml:"imagePullSecrets,omitempty"`
+	ServiceName      string                `yaml:"serviceName,omitempty"`
+	Namespace        string                `yaml:"namespace,omitempty"`
+	Domain           string                `yaml:"domain,omitempty"`
+	Ingress          Ingress               `yaml:"ingress,omitempty"`
+	PodLabels        map[string]string     `yaml:"podLabels,omitempty"`
+	NodeSelector     map[string]string     `yaml:"nodeSelector,omitempty"`
+	Tolerations      []Toleration          `yaml:"tolerations,omitempty"`
+	Resources        ReverseProxyResources `yaml:"resources,omitempty"`
+}
+
+type ReverseProxyResources struct {
+	Requests ReverseProxyResourceValues `yaml:"requests,omitempty"`
+	Limits   ReverseProxyResourceValues `yaml:"limits,omitempty"`
+}
+
+type ReverseProxyResourceValues struct {
+	CPU    string `yaml:"cpu,omitempty"`
+	Memory string `yaml:"memory,omitempty"`
 }
 
 type Ingress struct {

--- a/internal/unit_tests/helm_template_primaries_test.go
+++ b/internal/unit_tests/helm_template_primaries_test.go
@@ -2115,7 +2115,6 @@ func TestNeo4jResourcesAndLimits(t *testing.T) {
 		GenerateNeo4jResourcesTestCase([]string{"memoryRequests"}, "", "3Gi"),
 		GenerateNeo4jResourcesTestCase([]string{"cpuRequests", "memoryResources"}, "1", "3Gi"),
 		GenerateNeo4jResourcesTestCase([]string{"cpuResources", "memoryResources"}, "0.5", "3Gi"),
-		GenerateNeo4jResourcesTestCase([]string{"cpuRequests", "memoryRequests"}, "0.5", "3Gi"),
 		GenerateNeo4jResourcesTestCase([]string{"cpuResources", "memoryRequests"}, "0.5", "3Gi"),
 	}
 
@@ -2125,6 +2124,83 @@ func TestNeo4jResourcesAndLimits(t *testing.T) {
 				checkResourcesAndLimits(t, chart, edition, testCase)
 			})
 		}
+	}))
+}
+
+func TestNeo4jResourcesRequestsOnly(t *testing.T) {
+	t.Parallel()
+
+	forEachPrimaryChart(t, andEachSupportedEdition(func(t *testing.T, chart model.Neo4jHelmChartBuilder, edition string) {
+		var helmTemplateArgs []string
+		desiredFeatures := [][]string{
+			useNeo4jClusterName,
+			useDataModeAndAcceptLicense,
+			{"--set", "neo4j.resources.requests.cpu=500m", "--set", "neo4j.resources.requests.memory=2Gi"},
+		}
+		if edition == "enterprise" {
+			desiredFeatures = append(desiredFeatures, useEnterpriseAndAcceptLicense)
+		}
+		for _, a := range desiredFeatures {
+			helmTemplateArgs = append(helmTemplateArgs, a...)
+		}
+
+		manifest, err := model.HelmTemplate(t, chart, helmTemplateArgs)
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		statefulSets := manifest.OfType(&appsv1.StatefulSet{})
+		assert.Len(t, statefulSets, 1)
+
+		statefulSet := statefulSets[0].(*appsv1.StatefulSet)
+		assert.Len(t, statefulSet.Spec.Template.Spec.Containers, 1)
+		container := statefulSet.Spec.Template.Spec.Containers[0]
+
+		assert.Equal(t, "500m", container.Resources.Requests.Cpu().String())
+		assert.Equal(t, "2Gi", container.Resources.Requests.Memory().String())
+		assert.True(t, container.Resources.Limits.Cpu().IsZero(), "CPU limits should not be set when omitted in full format")
+		assert.True(t, container.Resources.Limits.Memory().IsZero(), "Memory limits should not be set when omitted in full format")
+	}))
+}
+
+func TestNeo4jResourcesIndependentLimits(t *testing.T) {
+	t.Parallel()
+
+	forEachPrimaryChart(t, andEachSupportedEdition(func(t *testing.T, chart model.Neo4jHelmChartBuilder, edition string) {
+		var helmTemplateArgs []string
+		desiredFeatures := [][]string{
+			useNeo4jClusterName,
+			useDataModeAndAcceptLicense,
+			{
+				"--set", "neo4j.resources.requests.cpu=500m",
+				"--set", "neo4j.resources.requests.memory=2Gi",
+				"--set", "neo4j.resources.limits.cpu=2000m",
+				"--set", "neo4j.resources.limits.memory=4Gi",
+			},
+		}
+		if edition == "enterprise" {
+			desiredFeatures = append(desiredFeatures, useEnterpriseAndAcceptLicense)
+		}
+		for _, a := range desiredFeatures {
+			helmTemplateArgs = append(helmTemplateArgs, a...)
+		}
+
+		manifest, err := model.HelmTemplate(t, chart, helmTemplateArgs)
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		statefulSets := manifest.OfType(&appsv1.StatefulSet{})
+		assert.Len(t, statefulSets, 1)
+
+		statefulSet := statefulSets[0].(*appsv1.StatefulSet)
+		assert.Len(t, statefulSet.Spec.Template.Spec.Containers, 1)
+		container := statefulSet.Spec.Template.Spec.Containers[0]
+
+		assert.Equal(t, "500m", container.Resources.Requests.Cpu().String())
+		assert.Equal(t, "2Gi", container.Resources.Requests.Memory().String())
+		assert.Equal(t, "2", container.Resources.Limits.Cpu().String())
+		assert.Equal(t, "4Gi", container.Resources.Limits.Memory().String())
 	}))
 }
 

--- a/internal/unit_tests/helm_template_reverseproxy_test.go
+++ b/internal/unit_tests/helm_template_reverseproxy_test.go
@@ -515,3 +515,59 @@ func TestReverseProxyNoExtraEnvVars(t *testing.T) {
 	assert.Nil(t, container.VolumeMounts, "volumeMounts should be nil when no extras specified")
 	assert.Nil(t, deployment.Spec.Template.Spec.Volumes, "volumes should be nil when no extras specified")
 }
+
+func TestReverseProxyResources(t *testing.T) {
+	t.Parallel()
+
+	helmValues := model.DefaultNeo4jReverseProxyValues
+	helmValues.ReverseProxy.ServiceName = "neo4j-service"
+	helmValues.ReverseProxy.Resources = model.ReverseProxyResources{
+		Requests: model.ReverseProxyResourceValues{
+			CPU:    "200m",
+			Memory: "256Mi",
+		},
+		Limits: model.ReverseProxyResourceValues{
+			CPU:    "1000m",
+			Memory: "512Mi",
+		},
+	}
+
+	manifests, err := model.HelmTemplateFromStruct(t, model.ReverseProxyHelmChart, helmValues)
+	assert.NoError(t, err, "error seen while testing resources with reverse proxy helm chart")
+
+	deploymentList := manifests.OfType(&appsv1.Deployment{})
+	assert.Len(t, deploymentList, 1, fmt.Sprintf("number of deployments should be 1, not %d", len(deploymentList)))
+
+	deployment := deploymentList[0].(*appsv1.Deployment)
+	containers := deployment.Spec.Template.Spec.Containers
+	assert.Len(t, containers, 1, "should have exactly one container")
+
+	resources := containers[0].Resources
+	assert.Equal(t, "200m", resources.Requests.Cpu().String(), "CPU request should match")
+	assert.Equal(t, "256Mi", resources.Requests.Memory().String(), "Memory request should match")
+	assert.Equal(t, "1", resources.Limits.Cpu().String(), "CPU limit should match")
+	assert.Equal(t, "512Mi", resources.Limits.Memory().String(), "Memory limit should match")
+}
+
+func TestReverseProxyDefaultResources(t *testing.T) {
+	t.Parallel()
+
+	helmValues := model.DefaultNeo4jReverseProxyValues
+	helmValues.ReverseProxy.ServiceName = "neo4j-service"
+
+	manifests, err := model.HelmTemplateFromStruct(t, model.ReverseProxyHelmChart, helmValues)
+	assert.NoError(t, err, "error seen while testing default resources with reverse proxy helm chart")
+
+	deploymentList := manifests.OfType(&appsv1.Deployment{})
+	assert.Len(t, deploymentList, 1, fmt.Sprintf("number of deployments should be 1, not %d", len(deploymentList)))
+
+	deployment := deploymentList[0].(*appsv1.Deployment)
+	containers := deployment.Spec.Template.Spec.Containers
+	assert.Len(t, containers, 1, "should have exactly one container")
+
+	resources := containers[0].Resources
+	assert.False(t, resources.Requests.Cpu().IsZero(), "default CPU request should not be zero")
+	assert.False(t, resources.Requests.Memory().IsZero(), "default memory request should not be zero")
+	assert.False(t, resources.Limits.Cpu().IsZero(), "default CPU limit should not be zero")
+	assert.False(t, resources.Limits.Memory().IsZero(), "default memory limit should not be zero")
+}

--- a/neo4j-reverse-proxy/templates/reverseProxyServer.yaml
+++ b/neo4j-reverse-proxy/templates/reverseProxyServer.yaml
@@ -46,6 +46,15 @@ spec:
             {{- with .Values.extraEnvVars }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- with .Values.reverseProxy.resources }}
+          resources:
+            {{- if or (hasKey . "limits") (hasKey . "requests") }}
+            {{- omit . "cpu" "memory" | toYaml | nindent 12 }}
+            {{- else }}
+            requests: {{ . | toYaml | nindent 14 }}
+            limits: {{ . | toYaml | nindent 14 }}
+            {{- end }}
+          {{- end }}
           {{- if .Values.extraVolumeMounts }}
           volumeMounts:
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}

--- a/neo4j-reverse-proxy/values.yaml
+++ b/neo4j-reverse-proxy/values.yaml
@@ -42,6 +42,15 @@ reverseProxy:
     fsGroup: 7474
     fsGroupChangePolicy: "Always"
 
+  # Resources for the reverse proxy container
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "128Mi"
+    limits:
+      cpu: "500m"
+      memory: "256Mi"
+
   # Pod labels for security policies and workload identification
   podLabels: {}
   #  app: "reverse-proxy"

--- a/neo4j/templates/_helpers.tpl
+++ b/neo4j/templates/_helpers.tpl
@@ -159,6 +159,7 @@ E.g. by adding `--set podSpec.loadbalancer=include`
 
     {{- end -}}
 
+    {{- $usesFullFormat := and $isCPUSet $isMemorySet }}
 
     {{- if not $isCPUSet }}
         {{- if kindIs "invalid" .Values.neo4j.resources.cpu -}}
@@ -179,8 +180,8 @@ E.g. by adding `--set podSpec.loadbalancer=include`
     {{- $requests := dict "cpu" $cpu "memory" $memory -}}
     {{- $ignored := set .Values.neo4j.resources "requests" $requests -}}
 
-    {{/* set limits as same as cpu and memory if not provided by the user */}}
-    {{- if kindIs "invalid" .Values.neo4j.resources.limits -}}
+    {{/* only auto-set limits when user uses shorthand or mixed format; full format allows omitting limits */}}
+    {{- if and (kindIs "invalid" .Values.neo4j.resources.limits) (not $usesFullFormat) -}}
        {{- $ignored := set .Values.neo4j.resources "limits" $requests -}}
     {{- end -}}
 

--- a/neo4j/values.yaml
+++ b/neo4j/values.yaml
@@ -71,7 +71,19 @@ neo4j:
   # this can be used to perform tasks that cannot be performed when Neo4j is running such as `neo4j-admin dump`
   offlineMaintenanceModeEnabled: false
   #
-  # set resources for the Neo4j Container. The values set will be used for both "requests" and "limit".
+  # Resources for the Neo4j Container. Two formats supported:
+  # 1. Shorthand (values used for both requests and limits):
+  #    resources:
+  #      cpu: "1000m"
+  #      memory: "2Gi"
+  # 2. Full format (limits can be set independently or omitted for bursting):
+  #    resources:
+  #      requests:
+  #        cpu: "500m"
+  #        memory: "2Gi"
+  #      limits:          # omit this section entirely to allow bursting
+  #        cpu: "2000m"
+  #        memory: "4Gi"
   resources:
     cpu: "1000m"
     memory: "2Gi"


### PR DESCRIPTION
## Summary

- Allow `neo4j.resources.limits` to be set independently from `requests`, or omitted entirely to enable pod bursting — addresses #526
- Add configurable `resources` (requests/limits) to the `neo4j-reverse-proxy` deployment container — incorporates the approach from #518
- Maintain full backward compatibility: shorthand format (`resources.cpu`/`resources.memory`) and mixed format continue to auto-set limits equal to requests; only when both `requests.cpu` and `requests.memory` are explicitly provided (full format) can limits be omitted

## Changes

**neo4j chart:**
- Modified `_helpers.tpl` to detect "full format" usage (both `requests.cpu` and `requests.memory` explicitly set) and skip auto-setting `limits = requests` in that case
- Updated `values.yaml` comments to document both shorthand and full format options

**neo4j-reverse-proxy chart:**
- Added `resources` block to `reverseProxyServer.yaml` template with support for both shorthand and explicit requests/limits
- Added `ReverseProxyResources` types to `reverse_proxy_values.go`
- Added default resource values to `values.yaml` (requests: 100m CPU / 128Mi memory, limits: 500m CPU / 256Mi memory)

**Tests:**
- Added `TestNeo4jResourcesRequestsOnly` - verifies limits are omitted when using full format without limits
- Added `TestNeo4jResourcesIndependentLimits` - verifies requests and limits can differ
- Added `TestReverseProxyResources` and `TestReverseProxyDefaultResources` for the new reverse proxy resource config
- Removed a test case from `TestNeo4jResourcesAndLimits` that conflicted with the new full-format behavior (now covered by the new tests)

## Backward Compatibility

Fully backward compatible. The default `values.yaml` still uses shorthand format, and the auto-set `limits = requests` behavior is preserved for shorthand and mixed format usage. Only explicit full-format users (setting both `requests.cpu` and `requests.memory`) gain the ability to omit limits.

## Related

- Closes #526
- Incorporates #518