### PR TITLE
Allow TLS enabled without tls.config when annotations provide certs

### DIFF
--- a/internal/unit_tests/helm_template_reverseproxy_test.go
+++ b/internal/unit_tests/helm_template_reverseproxy_test.go
@@ -76,15 +76,16 @@ func TestReverseProxyIngressWhenTLSEnabled(t *testing.T) {
 	assert.Equal(t, ingressTLS[0].SecretName, secretName, fmt.Sprintf("TLS config secret name %s not matching with %s", secretName, ingressTLS[0].SecretName))
 }
 
-// TestReverseProxyIngressEmptyConfigWhenTLSEnabled checks when tls config is not present
+// TestReverseProxyIngressEmptyConfigWhenTLSEnabled checks that TLS enabled with empty config
+// and no annotations fails with a descriptive error
 func TestReverseProxyIngressEmptyConfigWhenTLSEnabled(t *testing.T) {
 	t.Parallel()
 
 	helmValues := model.DefaultNeo4jReverseProxyValues
 	helmValues.ReverseProxy.Ingress.TLS.Config = nil
 	_, err := model.HelmTemplateFromStruct(t, model.ReverseProxyHelmChart, helmValues)
-	assert.Error(t, err, "no error found")
-	assert.Contains(t, err.Error(), "Empty tls config")
+	assert.Error(t, err, "TLS enabled with no config and no annotations should fail")
+	assert.Contains(t, err.Error(), "either tls.config or ingress annotations must be provided")
 }
 
 // TestReverseProxyIngressEmptySecretName checks if error is seen when no secretname is provided
@@ -99,6 +100,53 @@ func TestReverseProxyIngressEmptySecretName(t *testing.T) {
 	_, err := model.HelmTemplateFromStruct(t, model.ReverseProxyHelmChart, helmValues)
 	assert.Error(t, err, "no error found")
 	assert.Contains(t, err.Error(), "Empty secretName for tls config")
+}
+
+// TestReverseProxyIngressTLSEnabledWithAnnotationsNoConfig checks that TLS enabled with
+// annotations and no tls.config succeeds (annotation-based certificate management)
+func TestReverseProxyIngressTLSEnabledWithAnnotationsNoConfig(t *testing.T) {
+	t.Parallel()
+
+	helmValues := model.DefaultNeo4jReverseProxyValues
+	helmValues.ReverseProxy.Ingress.TLS.Config = nil
+	helmValues.ReverseProxy.Ingress.Annotations = map[string]string{
+		"cert-manager.io/cluster-issuer": "letsencrypt-prod",
+	}
+
+	manifests, err := model.HelmTemplateFromStruct(t, model.ReverseProxyHelmChart, helmValues)
+	assert.NoError(t, err, "TLS enabled with cert annotations and no tls.config should succeed")
+	ingressList := manifests.OfType(&v1.Ingress{})
+	assert.Len(t, ingressList, 1, fmt.Sprintf("number of ingress should be 1, not equal with %d", len(ingressList)))
+
+	ingress := ingressList[0].(*v1.Ingress)
+	assert.Nil(t, ingress.Spec.TLS, "tls block should not be rendered when tls.config is empty")
+	assert.Equal(t, "letsencrypt-prod", ingress.Annotations["cert-manager.io/cluster-issuer"], "cert-manager annotation should be present")
+
+	servicePort := ingress.Spec.Rules[0].HTTP.Paths[0].Backend.Service.Port.Number
+	assert.Equal(t, int32(443), servicePort, "service port should be 443 when TLS is enabled")
+}
+
+// TestReverseProxyIngressTLSConfigWithoutSecretName checks that TLS config entries
+// without a secretName are valid (ingress controller uses its default certificate)
+func TestReverseProxyIngressTLSConfigWithoutSecretName(t *testing.T) {
+	t.Parallel()
+
+	helmValues := model.DefaultNeo4jReverseProxyValues
+	helmValues.ReverseProxy.Ingress.TLS.Config = []model.Config{
+		{
+			Hosts: []string{"example.com"},
+		},
+	}
+
+	manifests, err := model.HelmTemplateFromStruct(t, model.ReverseProxyHelmChart, helmValues)
+	assert.NoError(t, err, "TLS config without secretName should succeed")
+	ingressList := manifests.OfType(&v1.Ingress{})
+	assert.Len(t, ingressList, 1, fmt.Sprintf("number of ingress should be 1, not equal with %d", len(ingressList)))
+
+	ingressTLS := ingressList[0].(*v1.Ingress).Spec.TLS
+	assert.NotNil(t, ingressTLS, "tls block should be rendered when tls.config has entries")
+	assert.Equal(t, "", ingressTLS[0].SecretName, "secretName should be empty")
+	assert.Equal(t, []string{"example.com"}, ingressTLS[0].Hosts, "hosts should match")
 }
 
 // TestReverseProxyIngressHostName checks if hostname is populated in the ingress definition or not

--- a/neo4j-reverse-proxy/templates/_validations.tpl
+++ b/neo4j-reverse-proxy/templates/_validations.tpl
@@ -1,15 +1,15 @@
 {{- define "neo4j.reverseProxy.tlsValidation" -}}
     {{- if and $.Values.reverseProxy.ingress.enabled $.Values.reverseProxy.ingress.tls.enabled -}}
         {{- if empty $.Values.reverseProxy.ingress.tls.config -}}
-            {{ fail (printf "Empty tls config !!") }}
-        {{- end -}}
-        {{- range $.Values.reverseProxy.ingress.tls.config -}}
-            {{- $value := . -}}
-            {{- if kindIs "invalid" $value.secretName  -}}
-                {{ fail (printf "Missing secretName for tls config") }}
+            {{- if empty $.Values.reverseProxy.ingress.annotations -}}
+                {{ fail (printf "When TLS is enabled, either tls.config or ingress annotations must be provided") }}
             {{- end -}}
-            {{- if empty ($value.secretName | trim)  -}}
-                {{ fail (printf "Empty secretName for tls config") }}
+        {{- else -}}
+            {{- range $.Values.reverseProxy.ingress.tls.config -}}
+                {{- $value := . -}}
+                {{- if and (not (kindIs "invalid" $value.secretName)) (empty ($value.secretName | trim)) -}}
+                    {{ fail (printf "Empty secretName for tls config") }}
+                {{- end -}}
             {{- end -}}
         {{- end -}}
     {{- end -}}

--- a/neo4j-reverse-proxy/templates/_validations.tpl
+++ b/neo4j-reverse-proxy/templates/_validations.tpl
@@ -7,8 +7,10 @@
         {{- else -}}
             {{- range $.Values.reverseProxy.ingress.tls.config -}}
                 {{- $value := . -}}
-                {{- if and (not (kindIs "invalid" $value.secretName)) (empty ($value.secretName | trim)) -}}
-                    {{ fail (printf "Empty secretName for tls config") }}
+                {{- if not (kindIs "invalid" $value.secretName) -}}
+                    {{- if empty ($value.secretName | trim) -}}
+                        {{ fail (printf "Empty secretName for tls config") }}
+                    {{- end -}}
                 {{- end -}}
             {{- end -}}
         {{- end -}}

--- a/neo4j-reverse-proxy/values.yaml
+++ b/neo4j-reverse-proxy/values.yaml
@@ -79,9 +79,18 @@ reverseProxy:
     annotations: {}
 #      "demo": "value"
 #      "demo2": "value2"
+#      # For annotation-based certificate management (no tls.config needed):
+#      # AWS ALB with ACM:
+#      #   "alb.ingress.kubernetes.io/certificate-arn": "arn:aws:acm:region:account:certificate/id"
+#      #   "alb.ingress.kubernetes.io/listen-ports": '[{"HTTPS":443}]'
+#      # cert-manager:
+#      #   "cert-manager.io/cluster-issuer": "letsencrypt-prod"
     host: ""
     tls:
       enabled: false
+      # tls.config is optional when certificates are managed via ingress annotations.
+      # When tls.config is empty and tls.enabled is true, TLS termination is handled
+      # by the ingress controller using the certificate specified in annotations.
       config: []
 #      - secretName: "demo2"
 #        hosts:


### PR DESCRIPTION
## Summary

- Allow `tls.enabled: true` with empty `tls.config` when ingress annotations are provided for certificate management (e.g., AWS ALB + ACM, cert-manager)
- Allow `tls.config` entries without a `secretName`
- Validate that at least one of `tls.config` or `annotations` is present when TLS is enabled, preventing silent misconfiguration
- Retain validation that catches whitespace-only `secretName` values

## Problem

When using annotation-based certificate management (e.g., `alb.ingress.kubernetes.io/certificate-arn` or `cert-manager.io/cluster-issuer`), users need `tls.enabled: true` to get port 443 but do not need `tls.config` entries with a `secretName`. The previous validation hard-failed with "Empty tls config !!" in this scenario, blocking a valid and common use case.

## Changes

- **`neo4j-reverse-proxy/templates/_validations.tpl`**: When TLS is enabled and `tls.config` is empty, require annotations to be set; `secretName` is now optional in config entries; whitespace-only `secretName` still fails
- **`neo4j-reverse-proxy/values.yaml`**: Added example annotations for AWS ACM and cert-manager, documented that `tls.config` is optional with annotation-based certs
- **`internal/unit_tests/helm_template_reverseproxy_test.go`**: Updated `TestReverseProxyIngressEmptyConfigWhenTLSEnabled` to expect error with new message; added `TestReverseProxyIngressTLSEnabledWithAnnotationsNoConfig` and `TestReverseProxyIngressTLSConfigWithoutSecretName`

## Backwards Compatibility

All existing valid configurations are unchanged:
- `tls.enabled: false` + empty config → no TLS (unchanged)
- `tls.enabled: true` + config with secretName → TLS block rendered (unchanged)
- `tls.enabled: true` + config with whitespace secretName → error (unchanged)
- `tls.enabled: true` + no config + no annotations → error (unchanged, message improved)

Only previously-failing configurations now succeed:
- `tls.enabled: true` + empty config + annotations → now OK
- `tls.enabled: true` + config entry without secretName → now OK

Part of HELM-16