### PR TITLE
Add reverse proxy service annotations

### DIFF
--- a/internal/model/reverse_proxy_values.go
+++ b/internal/model/reverse_proxy_values.go
@@ -15,11 +15,16 @@ type ReverseProxy struct {
 	ServiceName      string                `yaml:"serviceName,omitempty"`
 	Namespace        string                `yaml:"namespace,omitempty"`
 	Domain           string                `yaml:"domain,omitempty"`
+	Service          ReverseProxyService   `yaml:"service,omitempty"`
 	Ingress          Ingress               `yaml:"ingress,omitempty"`
 	PodLabels        map[string]string     `yaml:"podLabels,omitempty"`
 	NodeSelector     map[string]string     `yaml:"nodeSelector,omitempty"`
 	Tolerations      []Toleration          `yaml:"tolerations,omitempty"`
 	Resources        ReverseProxyResources `yaml:"resources,omitempty"`
+}
+
+type ReverseProxyService struct {
+	Annotations map[string]string `yaml:"annotations,omitempty"`
 }
 
 type ReverseProxyResources struct {

--- a/internal/unit_tests/helm_template_reverseproxy_test.go
+++ b/internal/unit_tests/helm_template_reverseproxy_test.go
@@ -29,6 +29,38 @@ func TestReverseProxyIngressWithAnnotations(t *testing.T) {
 	assert.Equal(t, ingressAnnotations, annotations, "ingress annotations are not matching")
 }
 
+func TestReverseProxyServiceWithAnnotations(t *testing.T) {
+	t.Parallel()
+
+	annotations := map[string]string{
+		"cloud.google.com/neg": `{"ingress": true}`,
+	}
+	helmValues := model.DefaultNeo4jReverseProxyValues
+	helmValues.ReverseProxy.Service.Annotations = annotations
+
+	manifests, err := model.HelmTemplateFromStruct(t, model.ReverseProxyHelmChart, helmValues)
+	assert.NoError(t, err, "error seen while testing service annotations with reverse proxy helm chart")
+	serviceList := manifests.OfType(&corev1.Service{})
+	assert.Len(t, serviceList, 1, fmt.Sprintf("number of services should be 1, not equal with %d", len(serviceList)))
+
+	service := serviceList[0].(*corev1.Service)
+	assert.Equal(t, annotations, service.Annotations, "service annotations are not matching")
+}
+
+func TestReverseProxyServiceWithoutAnnotations(t *testing.T) {
+	t.Parallel()
+
+	helmValues := model.DefaultNeo4jReverseProxyValues
+
+	manifests, err := model.HelmTemplateFromStruct(t, model.ReverseProxyHelmChart, helmValues)
+	assert.NoError(t, err, "error seen while testing default service annotations with reverse proxy helm chart")
+	serviceList := manifests.OfType(&corev1.Service{})
+	assert.Len(t, serviceList, 1, fmt.Sprintf("number of services should be 1, not equal with %d", len(serviceList)))
+
+	service := serviceList[0].(*corev1.Service)
+	assert.Empty(t, service.Annotations, "service annotations should be empty by default")
+}
+
 // TestReverseProxyIngressWhenDisabled checks for no presence of ingress when disabled
 func TestReverseProxyIngressWhenDisabled(t *testing.T) {
 	t.Parallel()

--- a/neo4j-reverse-proxy/templates/reverseProxyServer.yaml
+++ b/neo4j-reverse-proxy/templates/reverseProxyServer.yaml
@@ -69,6 +69,7 @@ kind: Service
 metadata:
   name: {{ include "neo4j.reverseProxy.fullname" . }}-reverseproxy-service
   namespace: "{{ .Release.Namespace }}"
+  {{- include "neo4j.reverseProxy.annotations" $.Values.reverseProxy.service.annotations | indent 2 }}
 spec:
   type: ClusterIP
   selector:
@@ -78,4 +79,3 @@ spec:
       port: {{ $port }}
       targetPort: {{ add $port 8000 }}
 ---
-

--- a/neo4j-reverse-proxy/values.yaml
+++ b/neo4j-reverse-proxy/values.yaml
@@ -25,6 +25,12 @@ reverseProxy:
   # default is set to cluster.local
   domain: "cluster.local"
 
+  # Annotations for the reverse proxy ClusterIP Service. These are separate from ingress annotations.
+  # On GKE, add cloud.google.com/neg to enable a NEG backend for an Ingress.
+  service:
+    annotations: {}
+#      "cloud.google.com/neg": '{"ingress": true}'
+
   # securityContext defines privilege and access control settings for a Container. Making sure that we dont run Neo4j as root user.
   containerSecurityContext:
     allowPrivilegeEscalation: false


### PR DESCRIPTION
Adds support for custom annotations on the reverse-proxy ClusterIP Service, enabling use cases such as GKE NEG backends.
Includes default values documentation and unit tests for configured and empty annotations.

Fixes HELM-21