### PR TITLE
Fix TLS certificate reloading for Neo4j

### DIFF
--- a/internal/integration_tests/k8s_client.go
+++ b/internal/integration_tests/k8s_client.go
@@ -151,12 +151,18 @@ func CheckServiceAnnotations(t *testing.T, releaseName model.ReleaseName, chart 
 
 func getOurAnnotations(service coreV1.Service) map[string]string {
 	ourAnnotations := map[string]string{}
+	annotationsToIgnore := map[string]struct{}{
+		"networking.gke.io/target-pool": {},
+	}
 	prefixesToIgnore := []string{
 		"cloud.google.com/",
 		"meta.helm.sh/",
 		"helm.sh/",
 	}
 	for key, value := range service.Annotations {
+		if _, ignored := annotationsToIgnore[key]; ignored {
+			continue
+		}
 		if !matchesAnyPrefix(prefixesToIgnore, key) {
 			ourAnnotations[key] = value
 		}

--- a/internal/integration_tests/k8s_client_test.go
+++ b/internal/integration_tests/k8s_client_test.go
@@ -1,0 +1,30 @@
+package integration_tests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	coreV1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetOurAnnotationsIgnoresGKEManagedTargetPool(t *testing.T) {
+	t.Parallel()
+
+	service := coreV1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"networking.gke.io/target-pool":        "gke-generated-target-pool",
+				"networking.gke.io/load-balancer-type": "Internal",
+				"cloud.google.com/neg-status":          "gke-generated-neg-status",
+				"meta.helm.sh/release-name":            "test-release",
+				"foo":                                  "bar",
+			},
+		},
+	}
+
+	assert.Equal(t, map[string]string{
+		"networking.gke.io/load-balancer-type": "Internal",
+		"foo":                                  "bar",
+	}, getOurAnnotations(service))
+}

--- a/internal/unit_tests/helm_template_ssl_test.go
+++ b/internal/unit_tests/helm_template_ssl_test.go
@@ -1,0 +1,64 @@
+package unit_tests
+
+import (
+	"testing"
+
+	"github.com/neo4j/helm-charts/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestSSLSecretsAreProjectedWithoutSubPath(t *testing.T) {
+	t.Parallel()
+
+	args := append([]string{}, useDataModeAndAcceptLicense...)
+	args = append(args, useNeo4jClusterName...)
+	args = append(args,
+		"--set", "ssl.bolt.privateKey.secretName=bolt-key-secret",
+		"--set", "ssl.bolt.privateKey.subPath=tls.key",
+		"--set", "ssl.bolt.publicCertificate.secretName=bolt-cert-secret",
+		"--set", "ssl.bolt.publicCertificate.subPath=tls.crt",
+	)
+
+	manifest, err := model.HelmTemplate(t, model.HelmChart, args)
+	require.NoError(t, err)
+
+	statefulSet := manifest.First(&appsv1.StatefulSet{}).(*appsv1.StatefulSet)
+	neo4jContainer := statefulSet.Spec.Template.Spec.Containers[0]
+
+	var certificateMount *v1.VolumeMount
+	for i := range neo4jContainer.VolumeMounts {
+		if neo4jContainer.VolumeMounts[i].Name == "bolt-certificates" {
+			certificateMount = &neo4jContainer.VolumeMounts[i]
+			break
+		}
+	}
+	require.NotNil(t, certificateMount)
+	assert.Equal(t, "/var/lib/neo4j/certificates/bolt", certificateMount.MountPath)
+	assert.Empty(t, certificateMount.SubPath)
+	assert.Empty(t, certificateMount.SubPathExpr)
+	assert.True(t, certificateMount.ReadOnly)
+
+	var certificateVolume *v1.Volume
+	for i := range statefulSet.Spec.Template.Spec.Volumes {
+		if statefulSet.Spec.Template.Spec.Volumes[i].Name == "bolt-certificates" {
+			certificateVolume = &statefulSet.Spec.Template.Spec.Volumes[i]
+			break
+		}
+	}
+	require.NotNil(t, certificateVolume)
+	require.NotNil(t, certificateVolume.Projected)
+	require.Len(t, certificateVolume.Projected.Sources, 2)
+
+	certificateSecret := certificateVolume.Projected.Sources[0].Secret
+	require.NotNil(t, certificateSecret)
+	assert.Equal(t, "bolt-cert-secret", certificateSecret.Name)
+	assert.Equal(t, []v1.KeyToPath{{Key: "tls.crt", Path: "public.crt"}}, certificateSecret.Items)
+
+	privateKeySecret := certificateVolume.Projected.Sources[1].Secret
+	require.NotNil(t, privateKeySecret)
+	assert.Equal(t, "bolt-key-secret", privateKeySecret.Name)
+	assert.Equal(t, []v1.KeyToPath{{Key: "tls.key", Path: "private.key"}}, privateKeySecret.Items)
+}

--- a/neo4j/templates/_ssl.tpl
+++ b/neo4j/templates/_ssl.tpl
@@ -1,12 +1,19 @@
 {{- define "neo4j.ssl.volumesFromSecrets" -}}
 {{- range $name, $sslSpec := . -}}
 {{- if ( or $sslSpec.privateKey.secretName $sslSpec.publicCertificate.secretName ) }}
-- name: "{{ $name }}-cert"
-  secret:
-    secretName: "{{ required "When ssl.{{ $name }}.publicCertificate is set then ssl.{{ $name }}.privateKey.secretName must also be provided" $sslSpec.publicCertificate.secretName }}"
-- name: "{{ $name }}-key"
-  secret:
-    secretName:  "{{ required "When ssl.bolt.privateKey is set then ssl.bolt.publicCertificate.secretName must also be provided" $sslSpec.privateKey.secretName }}"
+- name: "{{ $name }}-certificates"
+  projected:
+    sources:
+      - secret:
+          name: "{{ required "When ssl.{{ $name }}.privateKey is set then ssl.{{ $name }}.publicCertificate.secretName must also be provided" $sslSpec.publicCertificate.secretName }}"
+          items:
+            - key: "{{ $sslSpec.publicCertificate.subPath | default "public.crt" }}"
+              path: public.crt
+      - secret:
+          name: "{{ required "When ssl.{{ $name }}.publicCertificate is set then ssl.{{ $name }}.privateKey.secretName must also be provided" $sslSpec.privateKey.secretName }}"
+          items:
+            - key: "{{ $sslSpec.privateKey.subPath | default "private.key" }}"
+              path: private.key
 {{- if $sslSpec.trustedCerts.sources }}
 - name: "{{ $name }}-trusted"
   projected:
@@ -26,13 +33,8 @@
 {{- define "neo4j.ssl.volumeMountsFromSecrets" -}}
 {{- range $name, $sslSpec := . -}}
 {{- if ( or $sslSpec.privateKey.secretName $sslSpec.publicCertificate.secretName ) }}
-- name: "{{ $name }}-cert"
-  mountPath: /var/lib/neo4j/certificates/{{ $name }}/public.crt
-  subPath: "{{ $sslSpec.publicCertificate.subPath | default "public.crt" }}"
-  readOnly: true
-- name: "{{ $name }}-key"
-  mountPath: "/var/lib/neo4j/certificates/{{ $name }}/private.key"
-  subPath: "{{ $sslSpec.privateKey.subPath | default "private.key"  }}"
+- name: "{{ $name }}-certificates"
+  mountPath: "/var/lib/neo4j/certificates/{{ $name }}"
   readOnly: true
 {{- if $sslSpec.trustedCerts.sources }}
 - name: "{{ $name }}-trusted"

--- a/neo4j/values.yaml
+++ b/neo4j/values.yaml
@@ -460,10 +460,10 @@ ssl:
   bolt:
     privateKey:
       secretName:  # we set up the template to grab `private.key` from this secret
-      subPath:  # we specify the privateKey value name to get from the secret
+      subPath:  # key in the secret to project as `private.key`
     publicCertificate:
       secretName:  # we set up the template to grab `public.crt` from this secret
-      subPath:  # we specify the publicCertificate value name to get from the secret
+      subPath:  # key in the secret to project as `public.crt`
     trustedCerts:
       sources: [ ] # a sources array for a projected volume - this allows someone to (relatively) easily mount multiple public certs from multiple secrets for example.
     revokedCerts:


### PR DESCRIPTION
Neo4j supports reloading TLS certificates at runtime through dbms.security.tls_reload_enabled. However, the Helm chart currently mounts the certificate and private key using Kubernetes subPath volume mounts.
Kubernetes does not propagate Secret updates to files mounted with subPath. As a result, rotating a TLS Secret does not update the certificate files visible inside the Neo4j container, effectively preventing Neo4j’s TLS reload functionality from working. A pod restart is currently required for the new certificate to take effect.

This PR:
- Replaces the individual subPath mounts with a projected volume mounted at the SSL policy directory.
- Maps the selected Secret keys to Neo4j’s required public.crt and private.key filenames.
- Preserves compatibility with existing ssl.*.privateKey.subPath and ssl.*.publicCertificate.subPath values by using them as Secret key selectors.
- Allows Kubernetes to propagate Secret rotations into the running pod, enabling Neo4j to observe and reload updated TLS certificates.
- Adds regression coverage verifying that TLS mounts no longer use subPath and that custom Secret key names are projected correctly.