### PR TITLE
Publish 5.26 Helm charts to Google Artifact Registry

### DIFF
--- a/.github/workflows/package-and-release.yml
+++ b/.github/workflows/package-and-release.yml
@@ -13,7 +13,6 @@ on:
         required: true
 
 env:
-  GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
   CLOUDSDK_CORE_PROJECT: ${{ secrets.CLOUDSDK_CORE_PROJECT }}
   CLOUDSDK_COMPUTE_ZONE: "europe-west2-b"
   CLOUDSDK_COMPUTE_REGION: "europe-west2"
@@ -28,7 +27,7 @@ env:
   RESOURCE_PREFIX: ghactions
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   check-authorization:
@@ -76,16 +75,18 @@ jobs:
     needs: [check-authorization, build-reverseproxy-backup-release-image]
     runs-on: ubuntu-latest
     if: needs.check-authorization.outputs.should_run == 'true'
+    environment: helm-production
+    concurrency:
+      group: helm-production-release
+      cancel-in-progress: false
+    permissions:
+      actions: read
+      contents: write
+      id-token: write
     env:
       HELM_CHART_VERSION: ${{ inputs.HELM_CHART_VERSION }}
       DOCKER_IMAGE_VERSION: ${{ inputs.DOCKER_IMAGE_VERSION }}
       HELM_REPO_NAME: ${{ vars.HELM_REPO_NAME }}
-    container:
-      image: ${{ vars.ARTIFACT_REGISTRY_REPO_NAME }}/githubactions:${{ vars.CI_IMAGE_TAG || 'latest' }}
-      options: --user 1001
-      credentials:
-        username: _json_key
-        password: ${{ secrets.GCLOUD_SERVICE_KEY }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -94,6 +95,11 @@ jobs:
           fetch-tags: true
           token: ${{ secrets.GH_TOKEN }}
           ref: 5.26
+
+      - name: Set up Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
+        with:
+          version: v3.21.4
 
       - name: Version Updates
         run: |
@@ -119,30 +125,57 @@ jobs:
           git add CHANGELOG.md
 
       - name: GPG Key Signing
-        run: |
-          export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID_GPG }}
-          export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY_GPG }}
-          export ROLE_ARN_GPG=${{ secrets.ROLE_ARN_GPG }}
-          export SECRET_ID_GPG=${{ secrets.SECRET_ID_GPG }}          
-          ./bin/gcloud/gpg_signing          
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_GPG }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_GPG }}
+          ROLE_ARN_GPG: ${{ secrets.ROLE_ARN_GPG }}
+          SECRET_ID_GPG: ${{ secrets.SECRET_ID_GPG }}
+        run: ./bin/gcloud/gpg_signing
 
-      - name: Upload Helm Charts
+      - name: Package and verify Helm charts
+        env:
+          PACKAGE_SIGNING_KEY: ${{ secrets.PACKAGE_SIGNING_KEY }}
+          PACKAGE_SIGNING_PASSPHRASE: ${{ secrets.PACKAGE_SIGNING_PASSPHRASE }}
+        run: ./bin/release/package_charts
+
+      - name: Authenticate to Google Cloud
+        id: gcp-auth
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          project_id: ${{ vars.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_HELM_RELEASE_SERVICE_ACCOUNT }}
+          token_format: access_token
+
+      - name: Log in to Artifact Registry
+        env:
+          ACCESS_TOKEN: ${{ steps.gcp-auth.outputs.access_token }}
+          GAR_HOST: ${{ vars.HELM_OCI_LOCATION }}-docker.pkg.dev
         run: |
-          export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID_HELM }}
-          export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY_HELM }}
-          export AWS_REGION="us-east-1"          
-          export PACKAGE_SIGNING_KEY=${{ secrets.PACKAGE_SIGNING_KEY }}
-          export PACKAGE_SIGNING_PASSPHRASE=${{ secrets.PACKAGE_SIGNING_PASSPHRASE }}
-          ./bin/gcloud/package_upload          
+          printf '%s\n' "${ACCESS_TOKEN}" |
+            helm registry login "${GAR_HOST}" \
+              --username oauth2accesstoken \
+              --password-stdin
+
+      - name: Publish and verify OCI charts
+        env:
+          HELM_OCI_REGISTRY: ${{ vars.HELM_OCI_LOCATION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/${{ vars.HELM_OCI_REPOSITORY }}
+        run: ./bin/release/publish_oci
+
+      - name: Publish classic Helm repository
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_HELM }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_HELM }}
+          AWS_REGION: us-east-1
+        run: ./bin/release/publish_classic
 
       - name: Update index.yaml
-        run: |          
-          ./bin/gcloud/index_yaml_update
+        run: ./bin/gcloud/index_yaml_update
 
       - name: Set Chart Version
         id: chart_version
         run: |
-          echo "CHART_VERSION=${HELM_CHART_VERSION}" >> $GITHUB_OUTPUT
+          echo "CHART_VERSION=${HELM_CHART_VERSION}" >> "${GITHUB_OUTPUT}"
           echo "Using chart version ${HELM_CHART_VERSION} for release"
 
       - name: Release Notes
@@ -155,3 +188,5 @@ jobs:
           make_latest: true
           files: |
             tmp/new-packages/*.tgz
+            tmp/new-packages/*.tgz.prov
+            tmp/oci-digests.txt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -279,16 +279,18 @@ jobs:
     needs: [run-tests-debian, run-tests-redhat, build-reverseproxy-backup-release-image, check-release]
     runs-on: ubuntu-latest
     if: needs.check-release.outputs.should_run == 'true'
+    environment: helm-production
+    concurrency:
+      group: helm-production-release
+      cancel-in-progress: false
+    permissions:
+      actions: read
+      contents: write
+      id-token: write
     env:
       HELM_CHART_VERSION: ${{ inputs.HELM_CHART_VERSION }}
       DOCKER_IMAGE_VERSION: ${{ inputs.DOCKER_IMAGE_VERSION }}
       HELM_REPO_NAME: ${{ vars.HELM_REPO_NAME }}
-    container:
-      image: ${{ vars.ARTIFACT_REGISTRY_REPO_NAME }}/githubactions:${{ vars.CI_IMAGE_TAG || 'latest' }}
-      options: --user 1001
-      credentials:
-        username: _json_key
-        password: ${{ secrets.GCLOUD_SERVICE_KEY }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -297,6 +299,11 @@ jobs:
           fetch-tags: true
           token: ${{ secrets.GH_TOKEN }}
           ref: 5.26
+
+      - name: Set up Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
+        with:
+          version: v3.21.4
 
       - name: Version Updates
         run: |
@@ -322,30 +329,57 @@ jobs:
           git add CHANGELOG.md
 
       - name: GPG Key Signing
-        run: |
-          export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID_GPG }}
-          export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY_GPG }}
-          export ROLE_ARN_GPG=${{ secrets.ROLE_ARN_GPG }}
-          export SECRET_ID_GPG=${{ secrets.SECRET_ID_GPG }}          
-          ./bin/gcloud/gpg_signing          
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_GPG }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_GPG }}
+          ROLE_ARN_GPG: ${{ secrets.ROLE_ARN_GPG }}
+          SECRET_ID_GPG: ${{ secrets.SECRET_ID_GPG }}
+        run: ./bin/gcloud/gpg_signing
 
-      - name: Upload Helm Charts
+      - name: Package and verify Helm charts
+        env:
+          PACKAGE_SIGNING_KEY: ${{ secrets.PACKAGE_SIGNING_KEY }}
+          PACKAGE_SIGNING_PASSPHRASE: ${{ secrets.PACKAGE_SIGNING_PASSPHRASE }}
+        run: ./bin/release/package_charts
+
+      - name: Authenticate to Google Cloud
+        id: gcp-auth
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          project_id: ${{ vars.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_HELM_RELEASE_SERVICE_ACCOUNT }}
+          token_format: access_token
+
+      - name: Log in to Artifact Registry
+        env:
+          ACCESS_TOKEN: ${{ steps.gcp-auth.outputs.access_token }}
+          GAR_HOST: ${{ vars.HELM_OCI_LOCATION }}-docker.pkg.dev
         run: |
-          export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID_HELM }}
-          export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY_HELM }}
-          export AWS_REGION="us-east-1"          
-          export PACKAGE_SIGNING_KEY=${{ secrets.PACKAGE_SIGNING_KEY }}
-          export PACKAGE_SIGNING_PASSPHRASE=${{ secrets.PACKAGE_SIGNING_PASSPHRASE }}
-          ./bin/gcloud/package_upload          
+          printf '%s\n' "${ACCESS_TOKEN}" |
+            helm registry login "${GAR_HOST}" \
+              --username oauth2accesstoken \
+              --password-stdin
+
+      - name: Publish and verify OCI charts
+        env:
+          HELM_OCI_REGISTRY: ${{ vars.HELM_OCI_LOCATION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/${{ vars.HELM_OCI_REPOSITORY }}
+        run: ./bin/release/publish_oci
+
+      - name: Publish classic Helm repository
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_HELM }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_HELM }}
+          AWS_REGION: us-east-1
+        run: ./bin/release/publish_classic
 
       - name: Update index.yaml
-        run: |          
-          ./bin/gcloud/index_yaml_update
+        run: ./bin/gcloud/index_yaml_update
 
       - name: Set Chart Version
         id: chart_version
         run: |
-          echo "CHART_VERSION=${HELM_CHART_VERSION}" >> $GITHUB_OUTPUT
+          echo "CHART_VERSION=${HELM_CHART_VERSION}" >> "${GITHUB_OUTPUT}"
           echo "Using chart version ${HELM_CHART_VERSION} for release"
 
       - name: Release Notes
@@ -358,3 +392,5 @@ jobs:
           make_latest: true
           files: |
             tmp/new-packages/*.tgz
+            tmp/new-packages/*.tgz.prov
+            tmp/oci-digests.txt

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ devenv.local
 .DS_Store
 *.test
 .backup_linux
+__pycache__/
+*.pyc
+gha-creds-*.json

--- a/README.md
+++ b/README.md
@@ -8,6 +8,21 @@ Helm charts can be downloaded from [here](https://neo4j.com/deployment-center/#t
 
 [Full Documentation can be found here](https://neo4j.com/docs/operations-manual/current/kubernetes/)
 
+## OCI registry
+
+Released charts are also available from Google Artifact Registry as OCI
+artifacts. Specify the chart version explicitly:
+
+```bash
+helm install my-neo4j \
+  oci://europe-west2-docker.pkg.dev/neo4j-helm/helm-charts/neo4j \
+  --version 5.26.30 \
+  --values values.yaml
+```
+
+OCI registries do not use `helm repo add`. Release configuration and
+verification details are documented in [docs/ci/oci-release.md](docs/ci/oci-release.md).
+
 ## Examples
 See the `examples` directory for common usage patterns of this Helm Chart
 

--- a/bin/gcloud/gpg_signing
+++ b/bin/gcloud/gpg_signing
@@ -7,24 +7,33 @@ shopt -s inherit_errexit
 
 ROLE_ARN_GPG="${ROLE_ARN_GPG:?ROLE_ARN_GPG is required}"
 SECRET_ID_GPG="${SECRET_ID_GPG:?SECRET_ID_GPG is required}"
+AWS_CONFIG_DIR="${HOME}/.aws"
+AWS_CONFIG_FILE="${AWS_CONFIG_DIR}/config"
+SIGNING_KEY_FILE="signing-key.asc"
+SIGNING_SANDBOX="signingkeysandbox"
 
-#mkdir -p /root/.aws
-mkdir -p $HOME/.aws
+cleanup_signing_key_file() {
+  rm -f "${SIGNING_KEY_FILE}"
+}
 
-echo "[profile secrets]
-region = eu-west-1
-output = json
-role_arn = ${ROLE_ARN_GPG}
-credential_source = Environment" | tee $HOME/.aws/config
-#credential_source = Environment" | tee /root/.aws/config
+trap cleanup_signing_key_file EXIT
+
+mkdir -p "${AWS_CONFIG_DIR}"
+printf '%s\n' \
+  '[profile secrets]' \
+  'region = eu-west-1' \
+  'output = json' \
+  "role_arn = ${ROLE_ARN_GPG}" \
+  'credential_source = Environment' > "${AWS_CONFIG_FILE}"
 
 # fetch the key
-aws --profile secrets secretsmanager get-secret-value --secret-id ${SECRET_ID_GPG} | jq --raw-output '.SecretString' | jq --raw-output '.privateKey' | base64 --decode > signing-key.asc
+aws --profile secrets secretsmanager get-secret-value --secret-id "${SECRET_ID_GPG}" |
+  jq --raw-output '.SecretString' |
+  jq --raw-output '.privateKey' |
+  base64 --decode > "${SIGNING_KEY_FILE}"
 
 # stick it in a sandbox
-mkdir signingkeysandbox
-chmod 700 signingkeysandbox
-gpg --homedir signingkeysandbox --batch --import signing-key.asc || true
-#gpg --homedir signingkeysandbox --list-secret-keys
-# cleanup
-rm signing-key.asc
+rm -rf "${SIGNING_SANDBOX}"
+mkdir "${SIGNING_SANDBOX}"
+chmod 700 "${SIGNING_SANDBOX}"
+gpg --homedir "${SIGNING_SANDBOX}" --batch --import "${SIGNING_KEY_FILE}"

--- a/bin/gcloud/package_upload
+++ b/bin/gcloud/package_upload
@@ -1,72 +1,12 @@
 #!/usr/bin/env bash
 
-# This packages helm charts into signed tarballs
+# Compatibility entry point for the classic chart repository release path.
 
-# make bash play nicely
-#
 set -o pipefail -o errtrace -o errexit -o nounset
 shopt -s inherit_errexit
 [[ -n "${TRACE:-}" ]] && set -o xtrace
 
-# neo4j or neo4j-experimental
-S3_UPLOAD_TO_SUB_FOLDER="${HELM_REPO_NAME:?HELM_REPO_NAME is required}"
-PACKAGE_SIGNING_KEYRING_DIR="$HOME/.gnupg"
-mkdir -p ${PACKAGE_SIGNING_KEYRING_DIR}
-PACKAGE_SIGNING_KEYRING=${PACKAGE_SIGNING_KEYRING_DIR}/secring.gpg
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Local env vars
-#
-BUILD_OUT_DIR="tmp/new-packages/"
-S3_LOCAL_SYNC_DIR="tmp/release-packages"
-S3_CACHE_CONTROL_MAX_AGE_SECONDS="${S3_CACHE_CONTROL_MAX_AGE_SECONDS:-300}"
-
-# Required env vars
-#
-# to create a keyring try gpg --export-secret-keys "<ID of the key you want to use to sign>" >~/.gnupg/secring.gpg
-#PACKAGE_SIGNING_KEYRING="${PACKAGE_SIGNING_KEYRING:?PACKAGE_SIGNING_KEYRING is required}"
-PACKAGE_SIGNING_KEY="${PACKAGE_SIGNING_KEY:?PACKAGE_SIGNING_KEY is required}"
-PACKAGE_SIGNING_PASSPHRASE="${PACKAGE_SIGNING_PASSPHRASE:?PACKAGE_SIGNING_PASSPHRASE is required}"
-gpg --no-default-keyring --homedir signingkeysandbox --export -o ${PACKAGE_SIGNING_KEYRING_DIR}/pubring.gpg ${PACKAGE_SIGNING_KEY}
-gpg --no-default-keyring --homedir signingkeysandbox --export-secret-keys -o ${PACKAGE_SIGNING_KEYRING} ${PACKAGE_SIGNING_KEY}
-echo "Deleting sandbox"
-rm -rf signingkeysandbox
-
-if [ ${S3_UPLOAD_TO_SUB_FOLDER} == "neo4j" ]; then
-    CHART_VERSION=$(helm show chart ./neo4j| grep -E "version:(.*)" | awk -F ": " '{print $2}')
-    tar -czvf "neo4j-helm-charts-${CHART_VERSION}.tgz" neo4j neo4j-persistent-volume neo4j-headless-service neo4j-docker-desktop-pv neo4j-admin neo4j-reverse-proxy neo4j-loadbalancer
-    aws s3 cp --acl public-read "neo4j-helm-charts-${CHART_VERSION}.tgz" s3://dist.neo4j.org/helm/
-    rm -f "neo4j-helm-charts-${CHART_VERSION}.tgz"
-fi
-
-# create the package!
-echo $PACKAGE_SIGNING_PASSPHRASE | helm package --sign ./neo4j --key "${PACKAGE_SIGNING_KEY}" --keyring="${PACKAGE_SIGNING_KEYRING}" --passphrase-file -
-echo $PACKAGE_SIGNING_PASSPHRASE | helm package --sign ./neo4j-admin --key "${PACKAGE_SIGNING_KEY}" --keyring="${PACKAGE_SIGNING_KEYRING}" --passphrase-file -
-echo $PACKAGE_SIGNING_PASSPHRASE | helm package --sign ./neo4j-headless-service --key "${PACKAGE_SIGNING_KEY}" --keyring="${PACKAGE_SIGNING_KEYRING}" --passphrase-file -
-echo $PACKAGE_SIGNING_PASSPHRASE | helm package --sign ./neo4j-persistent-volume --key "${PACKAGE_SIGNING_KEY}" --keyring="${PACKAGE_SIGNING_KEYRING}" --passphrase-file -
-echo $PACKAGE_SIGNING_PASSPHRASE | helm package --sign ./neo4j-reverse-proxy --key "${PACKAGE_SIGNING_KEY}" --keyring="${PACKAGE_SIGNING_KEYRING}" --passphrase-file -
-echo $PACKAGE_SIGNING_PASSPHRASE | helm package --sign ./neo4j-loadbalancer --key "${PACKAGE_SIGNING_KEY}" --keyring="${PACKAGE_SIGNING_KEYRING}" --passphrase-file -
-# echo $PACKAGE_SIGNING_PASSPHRASE | helm package --sign ./neo4j-docker-desktop-pv --key "${PACKAGE_SIGNING_KEY}" --keyring="${PACKAGE_SIGNING_KEYRING}" --passphrase-file -
-
-echo "Copying packaged files to ${BUILD_OUT_DIR}"
-
-mkdir -p ${BUILD_OUT_DIR}
-mv *.tgz ${BUILD_OUT_DIR}
-mv *.tgz.prov ${BUILD_OUT_DIR}
-
-# Upload packages
-
-# Pull existing packages from s3
-#
-mkdir -p ${S3_LOCAL_SYNC_DIR}
-aws s3 sync s3://helm.neo4j.com/${S3_UPLOAD_TO_SUB_FOLDER} ${S3_LOCAL_SYNC_DIR}
-cp ${BUILD_OUT_DIR}/* ${S3_LOCAL_SYNC_DIR} || echo "nothing to upload in ./packages/"
-
-# Create index.yaml
-#
-helm repo index ${S3_LOCAL_SYNC_DIR} --url https://helm.neo4j.com/${S3_UPLOAD_TO_SUB_FOLDER}
-
-# Upload new packages to s3
-#
-aws s3 sync --acl bucket-owner-full-control --cache-control max-age=${S3_CACHE_CONTROL_MAX_AGE_SECONDS} ${S3_LOCAL_SYNC_DIR} s3://helm.neo4j.com/${S3_UPLOAD_TO_SUB_FOLDER}
-# Clean up local packages
-#rm ./packages/*
+"${SCRIPT_DIR}/../release/package_charts"
+"${SCRIPT_DIR}/../release/publish_classic"

--- a/bin/release/helm_release_common
+++ b/bin/release/helm_release_common
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+readonly RELEASE_CHARTS=(
+  neo4j
+  neo4j-admin
+  neo4j-headless-service
+  neo4j-persistent-volume
+  neo4j-reverse-proxy
+  neo4j-loadbalancer
+)
+
+readonly BUILD_OUT_DIR="tmp/new-packages"
+readonly PACKAGE_PUBLIC_KEYRING="tmp/signing/pubring.gpg"
+readonly PACKAGE_SECRET_KEYRING="tmp/signing/secring.gpg"
+
+fail() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "Required command not found: $1"
+}
+
+require_env() {
+  [[ -n "${!1:-}" ]] || fail "$1 is required"
+}
+
+chart_field() {
+  local chart_source="$1"
+  local field="$2"
+
+  helm show chart "${chart_source}" |
+    awk -F ': ' -v field="${field}" '$1 == field { print $2; exit }'
+}
+
+validate_release_packages() {
+  local expected_version="${HELM_CHART_VERSION:-}"
+  local chart
+  local package
+  local package_name
+  local package_version
+  local packages
+  local provenance_files
+
+  [[ -d "${BUILD_OUT_DIR}" ]] || fail "Package directory not found: ${BUILD_OUT_DIR}"
+
+  if [[ -z "${expected_version}" ]]
+  then
+    expected_version="$(chart_field neo4j version)"
+  fi
+
+  for chart in "${RELEASE_CHARTS[@]}"
+  do
+    package="${BUILD_OUT_DIR}/${chart}-${expected_version}.tgz"
+    [[ -f "${package}" ]] || fail "Missing package: ${package}"
+    [[ -f "${package}.prov" ]] || fail "Missing provenance file: ${package}.prov"
+
+    package_name="$(chart_field "${package}" name)"
+    package_version="$(chart_field "${package}" version)"
+    [[ "${package_name}" == "${chart}" ]] || fail "Unexpected chart name in ${package}: ${package_name}"
+    [[ "${package_version}" == "${expected_version}" ]] || fail "Unexpected chart version in ${package}: ${package_version}"
+  done
+
+  shopt -s nullglob
+  packages=("${BUILD_OUT_DIR}"/*.tgz)
+  provenance_files=("${BUILD_OUT_DIR}"/*.tgz.prov)
+  shopt -u nullglob
+
+  [[ "${#packages[@]}" -eq "${#RELEASE_CHARTS[@]}" ]] || fail "Expected ${#RELEASE_CHARTS[@]} packages, found ${#packages[@]}"
+  [[ "${#provenance_files[@]}" -eq "${#RELEASE_CHARTS[@]}" ]] || fail "Expected ${#RELEASE_CHARTS[@]} provenance files, found ${#provenance_files[@]}"
+}

--- a/bin/release/package_charts
+++ b/bin/release/package_charts
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+# Creates and verifies the signed chart packages used by every release destination.
+
+set -o pipefail -o errtrace -o errexit -o nounset
+shopt -s inherit_errexit
+[[ -n "${TRACE:-}" ]] && set -o xtrace
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bin/release/helm_release_common
+source "${SCRIPT_DIR}/helm_release_common"
+
+require_command gpg
+require_command helm
+require_env PACKAGE_SIGNING_KEY
+require_env PACKAGE_SIGNING_PASSPHRASE
+
+readonly SIGNING_SANDBOX="signingkeysandbox"
+
+cleanup_signing_material() {
+  rm -rf "${SIGNING_SANDBOX}"
+  rm -f "${PACKAGE_SECRET_KEYRING}"
+}
+
+trap cleanup_signing_material EXIT
+
+[[ -d "${SIGNING_SANDBOX}" ]] || fail "Signing sandbox not found. Run bin/gcloud/gpg_signing first"
+
+mkdir -p "${BUILD_OUT_DIR}" "$(dirname "${PACKAGE_PUBLIC_KEYRING}")"
+rm -f "${BUILD_OUT_DIR}"/*.tgz "${BUILD_OUT_DIR}"/*.tgz.prov
+
+gpg --batch --yes \
+  --no-default-keyring \
+  --homedir "${SIGNING_SANDBOX}" \
+  --export \
+  --output "${PACKAGE_PUBLIC_KEYRING}" \
+  "${PACKAGE_SIGNING_KEY}"
+
+printf '%s\n' "${PACKAGE_SIGNING_PASSPHRASE}" |
+  gpg --batch --yes \
+    --no-default-keyring \
+    --homedir "${SIGNING_SANDBOX}" \
+    --pinentry-mode loopback \
+    --passphrase-fd 0 \
+    --export-secret-keys \
+    --output "${PACKAGE_SECRET_KEYRING}" \
+    "${PACKAGE_SIGNING_KEY}"
+
+for chart in "${RELEASE_CHARTS[@]}"
+do
+  helm lint "${chart}"
+
+  printf '%s\n' "${PACKAGE_SIGNING_PASSPHRASE}" |
+    helm package \
+      --sign "${chart}" \
+      --key "${PACKAGE_SIGNING_KEY}" \
+      --keyring "${PACKAGE_SECRET_KEYRING}" \
+      --passphrase-file - \
+      --destination "${BUILD_OUT_DIR}"
+done
+
+validate_release_packages
+
+for package in "${BUILD_OUT_DIR}"/*.tgz
+do
+  helm verify "${package}" --keyring "${PACKAGE_PUBLIC_KEYRING}"
+done
+
+printf 'Created and verified %s signed chart packages in %s\n' "${#RELEASE_CHARTS[@]}" "${BUILD_OUT_DIR}"

--- a/bin/release/publish_classic
+++ b/bin/release/publish_classic
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# Publishes the already-created chart packages to the classic S3 Helm repository.
+
+set -o pipefail -o errtrace -o errexit -o nounset
+shopt -s inherit_errexit
+[[ -n "${TRACE:-}" ]] && set -o xtrace
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bin/release/helm_release_common
+source "${SCRIPT_DIR}/helm_release_common"
+
+require_command aws
+require_command helm
+require_command tar
+require_env HELM_REPO_NAME
+
+readonly S3_LOCAL_SYNC_DIR="tmp/release-packages"
+readonly S3_CACHE_CONTROL_MAX_AGE_SECONDS="${S3_CACHE_CONTROL_MAX_AGE_SECONDS:-300}"
+
+validate_release_packages
+
+if [[ "${HELM_REPO_NAME}" == "neo4j" ]]
+then
+  chart_version="$(chart_field neo4j version)"
+  source_bundle="neo4j-helm-charts-${chart_version}.tgz"
+
+  tar -czf "${source_bundle}" \
+    neo4j \
+    neo4j-persistent-volume \
+    neo4j-headless-service \
+    neo4j-docker-desktop-pv \
+    neo4j-admin \
+    neo4j-reverse-proxy \
+    neo4j-loadbalancer
+
+  aws s3 cp --acl public-read "${source_bundle}" s3://dist.neo4j.org/helm/
+  rm -f "${source_bundle}"
+fi
+
+rm -rf "${S3_LOCAL_SYNC_DIR}"
+mkdir -p "${S3_LOCAL_SYNC_DIR}"
+
+aws s3 sync "s3://helm.neo4j.com/${HELM_REPO_NAME}" "${S3_LOCAL_SYNC_DIR}"
+cp "${BUILD_OUT_DIR}"/*.tgz "${BUILD_OUT_DIR}"/*.tgz.prov "${S3_LOCAL_SYNC_DIR}/"
+
+helm repo index \
+  "${S3_LOCAL_SYNC_DIR}" \
+  --url "https://helm.neo4j.com/${HELM_REPO_NAME}"
+
+aws s3 sync \
+  --acl bucket-owner-full-control \
+  --cache-control "max-age=${S3_CACHE_CONTROL_MAX_AGE_SECONDS}" \
+  "${S3_LOCAL_SYNC_DIR}" \
+  "s3://helm.neo4j.com/${HELM_REPO_NAME}"
+
+printf 'Published the verified chart packages to https://helm.neo4j.com/%s\n' "${HELM_REPO_NAME}"

--- a/bin/release/publish_oci
+++ b/bin/release/publish_oci
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+
+# Publishes signed chart packages to an OCI registry and verifies the stored bytes.
+
+set -o pipefail -o errtrace -o errexit -o nounset
+shopt -s inherit_errexit
+[[ -n "${TRACE:-}" ]] && set -o xtrace
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bin/release/helm_release_common
+source "${SCRIPT_DIR}/helm_release_common"
+
+require_command cmp
+require_command diff
+require_command helm
+require_command tar
+require_env HELM_OCI_REGISTRY
+
+validate_release_packages
+[[ -f "${PACKAGE_PUBLIC_KEYRING}" ]] || fail "Public keyring not found: ${PACKAGE_PUBLIC_KEYRING}"
+
+HELM_OCI_REGISTRY="${HELM_OCI_REGISTRY#oci://}"
+HELM_OCI_REGISTRY="${HELM_OCI_REGISTRY%/}"
+readonly HELM_OCI_REGISTRY
+readonly OCI_DIGESTS_FILE="tmp/oci-digests.txt"
+VERIFY_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/helm-oci-verify.XXXXXX")"
+readonly VERIFY_ROOT
+
+cleanup_verification() {
+  rm -rf "${VERIFY_ROOT}"
+}
+
+trap cleanup_verification EXIT
+: > "${OCI_DIGESTS_FILE}"
+
+PULLED_PACKAGE=""
+PULLED_PROVENANCE=""
+PULLED_DIGEST=""
+
+pull_and_verify_remote() {
+  local chart="$1"
+  local version="$2"
+  local destination="$3"
+  local remote_ref="oci://${HELM_OCI_REGISTRY}/${chart}"
+  local pull_output
+
+  mkdir -p "${destination}"
+  pull_output="$(helm pull "${remote_ref}" \
+    --version "${version}" \
+    --prov \
+    --destination "${destination}")"
+  printf '%s\n' "${pull_output}"
+
+  PULLED_PACKAGE="${destination}/${chart}-${version}.tgz"
+  PULLED_PROVENANCE="${PULLED_PACKAGE}.prov"
+  PULLED_DIGEST="$(printf '%s\n' "${pull_output}" | awk '$1 == "Digest:" { print $2; exit }')"
+
+  [[ -f "${PULLED_PACKAGE}" ]] || fail "OCI pull did not create ${PULLED_PACKAGE}"
+  [[ -f "${PULLED_PROVENANCE}" ]] || fail "OCI pull did not create ${PULLED_PROVENANCE}"
+  [[ "${PULLED_DIGEST}" == sha256:* ]] || fail "OCI pull did not return a manifest digest for ${chart}:${version}"
+  helm verify "${PULLED_PACKAGE}" --keyring "${PACKAGE_PUBLIC_KEYRING}"
+}
+
+packages_have_equal_content() {
+  local local_package="$1"
+  local remote_package="$2"
+  local comparison_root="$3"
+
+  mkdir -p "${comparison_root}/local" "${comparison_root}/remote"
+  tar -xzf "${local_package}" -C "${comparison_root}/local"
+  tar -xzf "${remote_package}" -C "${comparison_root}/remote"
+  diff -r "${comparison_root}/local" "${comparison_root}/remote" >/dev/null
+}
+
+for chart in "${RELEASE_CHARTS[@]}"
+do
+  version="${HELM_CHART_VERSION:-$(chart_field "${chart}" version)}"
+  package="${BUILD_OUT_DIR}/${chart}-${version}.tgz"
+  provenance="${package}.prov"
+  remote_ref="oci://${HELM_OCI_REGISTRY}/${chart}"
+  chart_verify_root="${VERIFY_ROOT}/${chart}"
+
+  if helm show chart "${remote_ref}" --version "${version}" >/dev/null 2>&1
+  then
+    pull_and_verify_remote "${chart}" "${version}" "${chart_verify_root}/existing"
+
+    if ! cmp -s "${package}" "${PULLED_PACKAGE}" || ! cmp -s "${provenance}" "${PULLED_PROVENANCE}"
+    then
+      if ! packages_have_equal_content "${package}" "${PULLED_PACKAGE}" "${chart_verify_root}/content"
+      then
+        fail "OCI already contains different chart content for ${chart}:${version}"
+      fi
+
+      printf 'Reusing immutable OCI package bytes for %s:%s\n' "${chart}" "${version}"
+      cp "${PULLED_PACKAGE}" "${package}"
+      cp "${PULLED_PROVENANCE}" "${provenance}"
+    else
+      printf 'OCI already contains the verified package for %s:%s\n' "${chart}" "${version}"
+    fi
+  else
+    push_output="$(helm push "${package}" "oci://${HELM_OCI_REGISTRY}")"
+    printf '%s\n' "${push_output}"
+    push_digest="$(printf '%s\n' "${push_output}" | awk '$1 == "Digest:" { print $2; exit }')"
+
+    pull_and_verify_remote "${chart}" "${version}" "${chart_verify_root}/pushed"
+    cmp -s "${package}" "${PULLED_PACKAGE}" || fail "OCI package bytes differ after push for ${chart}:${version}"
+    cmp -s "${provenance}" "${PULLED_PROVENANCE}" || fail "OCI provenance bytes differ after push for ${chart}:${version}"
+
+    if [[ -n "${push_digest}" && "${push_digest}" != "${PULLED_DIGEST}" ]]
+    then
+      fail "OCI digest changed after push for ${chart}:${version}"
+    fi
+  fi
+
+  printf '%s/%s:%s@%s\n' \
+    "${HELM_OCI_REGISTRY}" \
+    "${chart}" \
+    "${version}" \
+    "${PULLED_DIGEST}" >> "${OCI_DIGESTS_FILE}"
+done
+
+validate_release_packages
+printf 'Published and verified %s OCI charts\n' "${#RELEASE_CHARTS[@]}"

--- a/docs/ci/oci-release.md
+++ b/docs/ci/oci-release.md
@@ -1,0 +1,73 @@
+# OCI Helm chart releases
+
+Release workflows publish the same signed chart archives to three destinations:
+
+* Google Artifact Registry as OCI artifacts
+* The classic S3 Helm repository
+* The GitHub release
+
+The OCI base path is:
+
+```text
+oci://europe-west2-docker.pkg.dev/neo4j-helm/helm-charts
+```
+
+The six published charts are `neo4j`, `neo4j-admin`,
+`neo4j-headless-service`, `neo4j-persistent-volume`,
+`neo4j-reverse-proxy`, and `neo4j-loadbalancer`.
+
+## Release flow
+
+`bin/release/package_charts` creates every signed `.tgz` and `.tgz.prov` file
+once. The release then runs these publishers in order:
+
+1. `bin/release/publish_oci` pushes and pulls every OCI chart, verifies its GPG
+   provenance, and compares the stored bytes.
+2. `bin/release/publish_classic` copies those verified package files to S3 and
+   rebuilds the classic repository index.
+3. `bin/gcloud/index_yaml_update` updates the repository index and release tag.
+4. The GitHub release attaches the same packages, provenance files, and OCI
+   digest list.
+
+Artifact Registry tags are immutable. On a retry, `publish_oci` verifies an
+existing chart and compares its extracted content with the new local package.
+When the content matches, the publisher restores the exact remote package and
+provenance bytes locally before the S3 and GitHub publication steps. Different
+chart content for an existing version stops the release.
+
+## GitHub configuration
+
+The `helm-production` environment must allow releases from `dev` and `5.26`.
+The release job requires these repository variables:
+
+| Variable | Value |
+| --- | --- |
+| `GCP_PROJECT_ID` | `neo4j-helm` |
+| `HELM_OCI_LOCATION` | `europe-west2` |
+| `HELM_OCI_REPOSITORY` | `helm-charts` |
+| `GCP_WORKLOAD_IDENTITY_PROVIDER` | Full Google workload identity provider name |
+| `GCP_HELM_RELEASE_SERVICE_ACCOUNT` | Dedicated Artifact Registry writer service account |
+
+The job requests `id-token: write` only for short-lived Google authentication.
+The release service account needs `roles/artifactregistry.writer` on the
+`helm-charts` repository and no project-wide role.
+
+## Consumer commands
+
+OCI repositories do not use `helm repo add`.
+
+```bash
+helm show chart \
+  oci://europe-west2-docker.pkg.dev/neo4j-helm/helm-charts/neo4j \
+  --version 5.26.30
+
+helm install my-neo4j \
+  oci://europe-west2-docker.pkg.dev/neo4j-helm/helm-charts/neo4j \
+  --version 5.26.30 \
+  --namespace neo4j \
+  --create-namespace \
+  --values values.yaml
+```
+
+See the [Helm OCI registry documentation](https://helm.sh/docs/topics/registries/)
+for more client commands.


### PR DESCRIPTION
## Summary

Add OCI-based Helm chart releases through Google Artifact Registry while preserving the existing S3 and GitHub release paths.

## Changes

- Split chart packaging from destination-specific publication
- Record OCI manifest digests as a GitHub release asset
- Document OCI installation and release operations