### PR TITLE
Backport S3 checksum options to 5.26

### DIFF
--- a/internal/model/backup_values.go
+++ b/internal/model/backup_values.go
@@ -66,37 +66,40 @@ type Neo4jBackupNeo4j struct {
 }
 
 type Backup struct {
-	BucketName               string          `yaml:"bucketName,omitempty"`
-	DatabaseAdminServiceName string          `yaml:"databaseAdminServiceName,omitempty"`
-	DatabaseAdminServiceIP   string          `yaml:"databaseAdminServiceIP,omitempty"`
-	DatabaseNamespace        string          `yaml:"databaseNamespace,omitempty" default:"default"`
-	DatabaseBackupPort       string          `yaml:"databaseBackupPort,omitempty" default:"6362"`
-	DatabaseClusterDomain    string          `yaml:"databaseClusterDomain,omitempty" default:"cluster.local"`
-	DatabaseBackupEndpoints  string          `yaml:"databaseBackupEndpoints,omitempty"`
-	Database                 string          `yaml:"database,omitempty"`
-	AzureStorageAccountName  string          `yaml:"azureStorageAccountName,omitempty"`
-	AzureBlobServiceURL      string          `yaml:"azureBlobServiceURL,omitempty"`
-	CloudProvider            string          `yaml:"cloudProvider,omitempty"`
-	S3Endpoint               string          `yaml:"s3Endpoint,omitempty"`
-	S3EndpointTLS            bool            `yaml:"s3EndpointTLS,omitempty" default:"false"`
-	S3CASecretName           string          `yaml:"s3CASecretName,omitempty"`
-	S3CASecretKey            string          `yaml:"s3CASecretKey,omitempty"`
-	S3SkipVerify             bool            `yaml:"s3SkipVerify,omitempty" default:"false"`
-	S3ForcePathStyle         bool            `yaml:"s3ForcePathStyle,omitempty" default:"true"`
-	S3Region                 string          `yaml:"s3Region,omitempty"`
-	S3SignatureVersion       string          `yaml:"s3SignatureVersion,omitempty"`
-	SecretName               string          `yaml:"secretName,omitempty"`
-	SecretKeyName            string          `yaml:"secretKeyName,omitempty"`
-	PageCache                string          `yaml:"pageCache,omitempty"`
-	HeapSize                 string          `yaml:"heapSize,omitempty"`
-	FallbackToFull           bool            `yaml:"fallbackToFull" default:"true"`
-	IncludeMetadata          string          `yaml:"includeMetadata,omitempty"`
-	Type                     string          `yaml:"type,omitempty"`
-	KeepFailed               bool            `yaml:"keepFailed" default:"false"`
-	ParallelRecovery         bool            `yaml:"parallelRecovery" default:"false"`
-	KeepBackupFiles          bool            `yaml:"keepBackupFiles" default:"true"`
-	Verbose                  bool            `yaml:"verbose" default:"true"`
-	AggregateBackup          AggregateBackup `yaml:"aggregate,omitempty"`
+	BucketName                   string          `yaml:"bucketName,omitempty"`
+	DatabaseAdminServiceName     string          `yaml:"databaseAdminServiceName,omitempty"`
+	DatabaseAdminServiceIP       string          `yaml:"databaseAdminServiceIP,omitempty"`
+	DatabaseNamespace            string          `yaml:"databaseNamespace,omitempty" default:"default"`
+	DatabaseBackupPort           string          `yaml:"databaseBackupPort,omitempty" default:"6362"`
+	DatabaseClusterDomain        string          `yaml:"databaseClusterDomain,omitempty" default:"cluster.local"`
+	DatabaseBackupEndpoints      string          `yaml:"databaseBackupEndpoints,omitempty"`
+	Database                     string          `yaml:"database,omitempty"`
+	AzureStorageAccountName      string          `yaml:"azureStorageAccountName,omitempty"`
+	AzureBlobServiceURL          string          `yaml:"azureBlobServiceURL,omitempty"`
+	CloudProvider                string          `yaml:"cloudProvider,omitempty"`
+	S3Endpoint                   string          `yaml:"s3Endpoint,omitempty"`
+	S3EndpointTLS                bool            `yaml:"s3EndpointTLS,omitempty" default:"false"`
+	S3CASecretName               string          `yaml:"s3CASecretName,omitempty"`
+	S3CASecretKey                string          `yaml:"s3CASecretKey,omitempty"`
+	S3SkipVerify                 bool            `yaml:"s3SkipVerify,omitempty" default:"false"`
+	S3ForcePathStyle             bool            `yaml:"s3ForcePathStyle,omitempty" default:"true"`
+	S3Region                     string          `yaml:"s3Region,omitempty"`
+	S3SignatureVersion           string          `yaml:"s3SignatureVersion,omitempty"`
+	S3RequestChecksumCalculation string          `yaml:"s3RequestChecksumCalculation,omitempty"`
+	S3ResponseChecksumValidation string          `yaml:"s3ResponseChecksumValidation,omitempty"`
+	S3DisableMultipartChecksums  bool            `yaml:"s3DisableMultipartChecksums,omitempty" default:"false"`
+	SecretName                   string          `yaml:"secretName,omitempty"`
+	SecretKeyName                string          `yaml:"secretKeyName,omitempty"`
+	PageCache                    string          `yaml:"pageCache,omitempty"`
+	HeapSize                     string          `yaml:"heapSize,omitempty"`
+	FallbackToFull               bool            `yaml:"fallbackToFull" default:"true"`
+	IncludeMetadata              string          `yaml:"includeMetadata,omitempty"`
+	Type                         string          `yaml:"type,omitempty"`
+	KeepFailed                   bool            `yaml:"keepFailed" default:"false"`
+	ParallelRecovery             bool            `yaml:"parallelRecovery" default:"false"`
+	KeepBackupFiles              bool            `yaml:"keepBackupFiles" default:"true"`
+	Verbose                      bool            `yaml:"verbose" default:"true"`
+	AggregateBackup              AggregateBackup `yaml:"aggregate,omitempty"`
 }
 
 type AggregateBackup struct {

--- a/internal/unit_tests/helm_template_backup_test.go
+++ b/internal/unit_tests/helm_template_backup_test.go
@@ -635,6 +635,64 @@ func TestBackupS3GenericParameters(t *testing.T) {
 	assert.Contains(t, envVariables, corev1.EnvVar{Name: "S3_SIGNATURE_VERSION", Value: "4"})
 }
 
+// TestAggregateBackupS3ChecksumConfiguration checks that S3 checksum options are set for aggregate backups
+func TestAggregateBackupS3ChecksumConfiguration(t *testing.T) {
+	t.Parallel()
+
+	helmValues := model.DefaultNeo4jBackupValues
+	helmValues.DisableLookups = true
+	helmValues.Backup.CloudProvider = "aws"
+	helmValues.Backup.AggregateBackup = model.AggregateBackup{
+		Enabled:  true,
+		FromPath: "s3://test-bucket",
+	}
+	helmValues.Backup.S3RequestChecksumCalculation = "WHEN_REQUIRED"
+	helmValues.Backup.S3ResponseChecksumValidation = "WHEN_REQUIRED"
+	helmValues.Backup.S3DisableMultipartChecksums = true
+	helmValues.ServiceAccountName = "backup-service-account"
+
+	manifests, err := model.HelmTemplateFromStruct(t, model.BackupHelmChart, helmValues)
+	assert.NoError(t, err)
+
+	cronjobs := manifests.OfType(&batchv1.CronJob{})
+	assert.Len(t, cronjobs, 1, "there should be only one cronjob")
+
+	envVariables := cronjobs[0].(*batchv1.CronJob).Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env
+	assert.Contains(t, envVariables, corev1.EnvVar{Name: "AWS_REQUEST_CHECKSUM_CALCULATION", Value: "WHEN_REQUIRED"})
+	assert.Contains(t, envVariables, corev1.EnvVar{Name: "AWS_RESPONSE_CHECKSUM_VALIDATION", Value: "WHEN_REQUIRED"})
+	assert.Contains(t, envVariables, corev1.EnvVar{Name: "AWS_S3_DISABLE_MULTIPART_CHECKSUMS", Value: "true"})
+}
+
+// TestAggregateBackupS3ChecksumDefaults checks that unset S3 checksum options preserve AWS SDK defaults
+func TestAggregateBackupS3ChecksumDefaults(t *testing.T) {
+	t.Parallel()
+
+	helmValues := model.DefaultNeo4jBackupValues
+	helmValues.DisableLookups = true
+	helmValues.Backup.CloudProvider = "aws"
+	helmValues.Backup.AggregateBackup = model.AggregateBackup{
+		Enabled:  true,
+		FromPath: "s3://test-bucket",
+	}
+	helmValues.ServiceAccountName = "backup-service-account"
+
+	manifests, err := model.HelmTemplateFromStruct(t, model.BackupHelmChart, helmValues)
+	assert.NoError(t, err)
+
+	cronjobs := manifests.OfType(&batchv1.CronJob{})
+	assert.Len(t, cronjobs, 1, "there should be only one cronjob")
+
+	checksumEnvNames := []string{
+		"AWS_REQUEST_CHECKSUM_CALCULATION",
+		"AWS_RESPONSE_CHECKSUM_VALIDATION",
+		"AWS_S3_DISABLE_MULTIPART_CHECKSUMS",
+	}
+	envVariables := cronjobs[0].(*batchv1.CronJob).Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env
+	for _, envVariable := range envVariables {
+		assert.NotContains(t, checksumEnvNames, envVariable.Name)
+	}
+}
+
 // TestBackupAzureBlobServiceURL checks that the Azure blob service URL is properly configured
 func TestBackupAzureBlobServiceURL(t *testing.T) {
 	t.Parallel()

--- a/neo4j-admin/backup/neo4j-admin/operations.go
+++ b/neo4j-admin/backup/neo4j-admin/operations.go
@@ -190,6 +190,9 @@ func PerformAggregateBackup() error {
 	flags := GetAggregateBackupCommandFlags()
 	database := os.Getenv("AGGREGATE_BACKUP_DATABASE")
 	log.Printf("Printing aggregate backup flags %v", flags)
+	log.Printf("AWS_REQUEST_CHECKSUM_CALCULATION: %s", os.Getenv("AWS_REQUEST_CHECKSUM_CALCULATION"))
+	log.Printf("AWS_RESPONSE_CHECKSUM_VALIDATION: %s", os.Getenv("AWS_RESPONSE_CHECKSUM_VALIDATION"))
+	log.Printf("AWS_S3_DISABLE_MULTIPART_CHECKSUMS: %s", os.Getenv("AWS_S3_DISABLE_MULTIPART_CHECKSUMS"))
 	dir, _ := os.Getwd()
 	log.Println("current directory", dir)
 

--- a/neo4j-admin/templates/NOTES.txt
+++ b/neo4j-admin/templates/NOTES.txt
@@ -23,6 +23,16 @@ For S3-compatible storage providers (like Cloudian, MinIO, etc.):
 1. If you encounter signature errors, try setting s3Region to a fixed value like "us-east-1"
 2. Ensure s3ForcePathStyle is set to true
 3. For older S3 implementations, try setting s3SignatureVersion to "2"
+4. If you encounter checksum mismatch errors, try all of these settings together:
+   - Set s3RequestChecksumCalculation to "WHEN_REQUIRED"
+   - Set s3ResponseChecksumValidation to "WHEN_REQUIRED"
+   - Set s3DisableMultipartChecksums to true
+
+   Example configuration:
+   backup:
+     s3RequestChecksumCalculation: "WHEN_REQUIRED"
+     s3ResponseChecksumValidation: "WHEN_REQUIRED"
+     s3DisableMultipartChecksums: true
 {{- end }}
 {{- end }}
 

--- a/neo4j-admin/templates/neo4j-cronjob.yaml
+++ b/neo4j-admin/templates/neo4j-cronjob.yaml
@@ -105,6 +105,18 @@ spec:
                   value: "{{ .Values.backup.s3Region | default "" }}"
                 - name: S3_SIGNATURE_VERSION
                   value: "{{ .Values.backup.s3SignatureVersion | default "" }}"
+                {{- if .Values.backup.s3RequestChecksumCalculation }}
+                - name: AWS_REQUEST_CHECKSUM_CALCULATION
+                  value: "{{ .Values.backup.s3RequestChecksumCalculation }}"
+                {{- end }}
+                {{- if .Values.backup.s3ResponseChecksumValidation }}
+                - name: AWS_RESPONSE_CHECKSUM_VALIDATION
+                  value: "{{ .Values.backup.s3ResponseChecksumValidation }}"
+                {{- end }}
+                {{- if .Values.backup.s3DisableMultipartChecksums }}
+                - name: AWS_S3_DISABLE_MULTIPART_CHECKSUMS
+                  value: "true"
+                {{- end }}
                 - name: CONSISTENCY_CHECK_ENABLE
                   value: "{{ .Values.consistencyCheck.enable | default false }}"
                 - name: CONSISTENCY_CHECK_INDEXES
@@ -178,5 +190,4 @@ spec:
 {{- else }}
   {{- printf "emptyDir: {}" | nindent 14 }}
 {{- end }}
-
 

--- a/neo4j-admin/values.yaml
+++ b/neo4j-admin/values.yaml
@@ -83,6 +83,23 @@ backup:
   # Valid values: "2", "4", or "" (empty for auto-detection)
   s3SignatureVersion: ""
 
+  # AWS SDK checksum configuration for S3 uploads
+  # These settings are useful for S3-compatible endpoints that do not support newer checksum requirements
+
+  # Control when the AWS SDK calculates request checksums
+  # Valid values: "WHEN_SUPPORTED" (default), "WHEN_REQUIRED", or "" to use the AWS SDK default
+  # Set to "WHEN_REQUIRED" when the endpoint does not support automatic checksum calculation
+  s3RequestChecksumCalculation: ""
+
+  # Control when the AWS SDK validates response checksums
+  # Valid values: "WHEN_SUPPORTED" (default), "WHEN_REQUIRED", or "" to use the AWS SDK default
+  # Set to "WHEN_REQUIRED" when the endpoint does not support automatic checksum validation
+  s3ResponseChecksumValidation: ""
+
+  # Disable checksums for multipart uploads
+  # Set to true together with the options above when an S3-compatible endpoint reports checksum mismatch errors
+  s3DisableMultipartChecksums: false
+
   #name of the database to backup ex: neo4j or neo4j,system (You can provide command separated database names)
   # In case of comma separated databases failure of any single database will lead to failure of complete operation
   database: ""
@@ -262,4 +279,3 @@ tolerations: []
 #    operator: "Equal"
 #    value: "value2"
 #    effect: "NoSchedule"
-


### PR DESCRIPTION
## Summary

- add Helm values for AWS request checksum calculation, response checksum validation, and multipart checksum disabling
- map configured values to the backup container while preserving AWS SDK defaults when unset
- log aggregate backup checksum settings and document the recommended S3-compatible endpoint configuration
- add rendered-manifest coverage for configured and default behavior

## Testing

- focused aggregate backup checksum unit tests
- helm lint neo4j-admin
- backup module package compilation

Fixes HELM-38